### PR TITLE
Feature/17 chip component

### DIFF
--- a/src/components/shared/chip/index.tsx
+++ b/src/components/shared/chip/index.tsx
@@ -1,9 +1,7 @@
-import Chip from '@mui/material/Chip';
+import Chip, { ChipProps } from '@mui/material/Chip';
 
-interface BasicChipProps {
+interface BasicChipProps extends ChipProps {
   label: string;
-  key?: string;
-  onClick?: () => void;
 }
 const BasicChip = ({ label, ...props }: BasicChipProps) => {
   return <Chip label={label} {...props} />;

--- a/src/components/shared/chip/index.tsx
+++ b/src/components/shared/chip/index.tsx
@@ -1,0 +1,7 @@
+import Chip from '@mui/material/Chip';
+
+const BasicChip = ({ ...props }) => {
+  return <Chip {...props} />;
+};
+
+export default BasicChip;

--- a/src/components/shared/chip/index.tsx
+++ b/src/components/shared/chip/index.tsx
@@ -1,7 +1,10 @@
 import Chip from '@mui/material/Chip';
 
-const BasicChip = ({ ...props }) => {
-  return <Chip {...props} />;
+interface BasicChipProps {
+  label: string;
+}
+const BasicChip = ({ label, ...props }: BasicChipProps) => {
+  return <Chip label={label} {...props} />;
 };
 
 export default BasicChip;

--- a/src/components/shared/chip/index.tsx
+++ b/src/components/shared/chip/index.tsx
@@ -2,6 +2,8 @@ import Chip from '@mui/material/Chip';
 
 interface BasicChipProps {
   label: string;
+  key?: string;
+  onClick?: () => void;
 }
 const BasicChip = ({ label, ...props }: BasicChipProps) => {
   return <Chip label={label} {...props} />;

--- a/src/components/shared/chipGroup/index.tsx
+++ b/src/components/shared/chipGroup/index.tsx
@@ -1,0 +1,19 @@
+import Stack from '@mui/material/Stack';
+
+import BasicChip from '@/components/shared/chip';
+
+interface ChipGroupProps {
+  labels: string[];
+}
+
+const ChipGroup = ({ labels }: ChipGroupProps) => {
+  return (
+    <Stack direction="row" spacing={1}>
+      {labels?.map((label: string, i) => (
+        <BasicChip label={label} key={label + i} />
+      ))}
+    </Stack>
+  );
+};
+
+export default ChipGroup;

--- a/src/components/shared/chipGroup/index.tsx
+++ b/src/components/shared/chipGroup/index.tsx
@@ -1,17 +1,13 @@
 import Stack from '@mui/material/Stack';
 
-import BasicChip from '@/components/shared/chip';
-
 interface ChipGroupProps {
-  labels: string[];
+  children: React.ReactNode;
 }
 
-const ChipGroup = ({ labels, ...props }: ChipGroupProps) => {
+const ChipGroup = ({ children, ...props }: ChipGroupProps) => {
   return (
-    <Stack direction="row" spacing={1}>
-      {labels?.map((label: string, i) => (
-        <BasicChip label={label} key={label + i} {...props} />
-      ))}
+    <Stack direction="row" spacing={1} {...props}>
+      {children}
     </Stack>
   );
 };

--- a/src/components/shared/chipGroup/index.tsx
+++ b/src/components/shared/chipGroup/index.tsx
@@ -6,11 +6,11 @@ interface ChipGroupProps {
   labels: string[];
 }
 
-const ChipGroup = ({ labels }: ChipGroupProps) => {
+const ChipGroup = ({ labels, ...props }: ChipGroupProps) => {
   return (
     <Stack direction="row" spacing={1}>
       {labels?.map((label: string, i) => (
-        <BasicChip label={label} key={label + i} />
+        <BasicChip label={label} key={label + i} {...props} />
       ))}
     </Stack>
   );


### PR DESCRIPTION
## 기능 이름
BasicChip 컴포넌트
ChipGroup 컴포넌트

## 기능 설명
현재 접속 중인 개발자, 추천 개발자에서 사용되는 chip과 Technical stack에 사용되는 chip group 컴포넌트입니다.

사용방법은 다음과 같습니다.
```ts
<BasicChip label="Frontend" variant="outlined" />

<ChipGroup>
  {['React', 'TypeScript', 'Vue']?.map((label: string, i) => (
    <BasicChip
      label={label}
      key={label + i}
      onClick={() => console.log(label)}
    />
  ))}
</ChipGroup>
```
## 구현 내용
<!-- ## 스크린샷 - UI 관련인 경우 꼭 넣기! -->
<!-- ## 장애물 - 기능 구현 중 있었던 이슈 -->  
![image](https://github.com/prgrms-fe-devcourse/FEDC4_CUCUMIS_Pocojang/assets/87280835/ce5a46d3-d942-4158-b04d-62ef82a58ac0)


## PR 포인트
<!--리뷰어가 집중했으면 하는 부분 -->  


## 참고 사항
<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->  


## 궁금한 점
<!-- ## 이슈 번호 - close -->
<!--## 완료 사항-->  
- 컴포넌트 추상화가 제대로 이뤄졌는지 궁금합니다
