### PR TITLE
Feature/28 basic input component

### DIFF
--- a/src/components/shared/input/index.tsx
+++ b/src/components/shared/input/index.tsx
@@ -1,0 +1,54 @@
+import { useState } from 'react';
+import TextField from '@mui/material/TextField';
+
+interface BasicInputProps {
+  type?: string; // 기본 search(x버튼 존재), password, number(연차)
+  label: string; // input의 제목
+  isRequired?: boolean; // 기본 true
+  defaultValue?: string;
+  regExp?: string; // 각 필드별 정규식 패턴
+  errorMessage?: string;
+  // value: Record<string, string>;
+  setValue?: React.Dispatch<React.SetStateAction<object>>;
+}
+
+const BasicInput = ({
+  type = 'search',
+  label,
+  isRequired = true,
+  defaultValue,
+  regExp,
+  errorMessage,
+  setValue,
+}: BasicInputProps) => {
+  const [isError, setIsError] = useState(false);
+
+  const handleInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.currentTarget;
+
+    setValue &&
+      setValue((prev: object) => ({
+        ...prev,
+        [name]: value,
+      }));
+
+    if (regExp) {
+      setIsError(!new RegExp(regExp).test(value));
+    }
+  };
+
+  return (
+    <TextField
+      onChange={handleInput}
+      required={isRequired}
+      name={label}
+      label={label}
+      defaultValue={defaultValue}
+      type={type}
+      error={isError}
+      helperText={isError ? errorMessage : ''}
+    />
+  );
+};
+
+export default BasicInput;

--- a/src/components/shared/input/index.tsx
+++ b/src/components/shared/input/index.tsx
@@ -11,7 +11,7 @@ const BasicInput = ({
   regExp,
   errorMessage,
   inputRef,
-}: BasicInputProps) => {
+}: BasicInputProps<object>) => {
   const { isError, handleInput } = useInput({ inputRef, regExp });
 
   return (

--- a/src/components/shared/input/index.tsx
+++ b/src/components/shared/input/index.tsx
@@ -1,7 +1,8 @@
 import { useState, MutableRefObject } from 'react';
 import TextField from '@mui/material/TextField';
+import styled from '@emotion/styled';
 
-interface BasicInputProps {
+export interface BasicInputProps {
   type?: string; // 기본 search(x버튼 존재), password, number(연차)
   label: string; // input의 제목
   isRequired?: boolean; // 기본 true
@@ -10,6 +11,7 @@ interface BasicInputProps {
   errorMessage?: string;
   inputRef: MutableRefObject<object>;
 }
+// textfield : multiline, searchbar
 
 const BasicInput = ({
   type = 'search',
@@ -33,17 +35,39 @@ const BasicInput = ({
   };
 
   return (
-    <TextField
-      onChange={handleInput}
-      required={isRequired}
-      name={label}
-      label={label}
-      defaultValue={defaultValue}
-      type={type}
-      error={isError}
-      helperText={isError ? errorMessage : ''}
-    />
+    <>
+      {label === 'search' ? (
+        <SearchTextFieldStyled
+          type="search"
+          variant="filled"
+          hiddenLabel
+          onChange={handleInput}
+          required={isRequired}
+          name={label}
+          placeholder="검색어를 입력해주세요"
+          fullWidth
+        />
+      ) : (
+        <TextField
+          onChange={handleInput}
+          required={isRequired}
+          name={label}
+          label={label}
+          defaultValue={defaultValue}
+          type={type}
+          error={isError}
+          helperText={isError ? errorMessage : ''}
+          multiline={type === 'multiline'}
+          fullWidth
+        />
+      )}
+    </>
   );
 };
+
+const SearchTextFieldStyled = styled(TextField)({
+  borderRadius: '20px;',
+  overflow: 'hidden',
+});
 
 export default BasicInput;

--- a/src/components/shared/input/index.tsx
+++ b/src/components/shared/input/index.tsx
@@ -1,6 +1,8 @@
-import { useState, MutableRefObject } from 'react';
+import { MutableRefObject } from 'react';
 import TextField from '@mui/material/TextField';
 import styled from '@emotion/styled';
+
+import useInput from '@/hooks/components/useInput';
 
 export interface BasicInputProps {
   type?: string; // 기본 search(x버튼 존재), password, number(연차)
@@ -22,17 +24,7 @@ const BasicInput = ({
   errorMessage,
   inputRef,
 }: BasicInputProps) => {
-  const [isError, setIsError] = useState(false);
-
-  const handleInput = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const { name, value } = e.currentTarget;
-
-    if (regExp) {
-      setIsError(!new RegExp(regExp).test(value));
-    }
-
-    inputRef.current = { ...inputRef.current, [name]: value };
-  };
+  const { isError, handleInput } = useInput({ inputRef, regExp });
 
   return (
     <>

--- a/src/components/shared/input/index.tsx
+++ b/src/components/shared/input/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, MutableRefObject } from 'react';
 import TextField from '@mui/material/TextField';
 
 interface BasicInputProps {
@@ -8,8 +8,7 @@ interface BasicInputProps {
   defaultValue?: string;
   regExp?: string; // 각 필드별 정규식 패턴
   errorMessage?: string;
-  // value: Record<string, string>;
-  setValue?: React.Dispatch<React.SetStateAction<object>>;
+  inputRef: MutableRefObject<object>;
 }
 
 const BasicInput = ({
@@ -19,22 +18,18 @@ const BasicInput = ({
   defaultValue,
   regExp,
   errorMessage,
-  setValue,
+  inputRef,
 }: BasicInputProps) => {
   const [isError, setIsError] = useState(false);
 
   const handleInput = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.currentTarget;
 
-    setValue &&
-      setValue((prev: object) => ({
-        ...prev,
-        [name]: value,
-      }));
-
     if (regExp) {
       setIsError(!new RegExp(regExp).test(value));
     }
+
+    inputRef.current = { ...inputRef.current, [name]: value };
   };
 
   return (

--- a/src/components/shared/input/index.tsx
+++ b/src/components/shared/input/index.tsx
@@ -1,19 +1,7 @@
-import { MutableRefObject } from 'react';
 import TextField from '@mui/material/TextField';
-import styled from '@emotion/styled';
 
 import useInput from '@/hooks/components/useInput';
-
-export interface BasicInputProps {
-  type?: string; // 기본 search(x버튼 존재), password, number(연차)
-  label: string; // input의 제목
-  isRequired?: boolean; // 기본 true
-  defaultValue?: string;
-  regExp?: string; // 각 필드별 정규식 패턴
-  errorMessage?: string;
-  inputRef: MutableRefObject<object>;
-}
-// textfield : multiline, searchbar
+import { BasicInputProps } from '@/types/components/BasicInputProps';
 
 const BasicInput = ({
   type = 'search',
@@ -27,39 +15,19 @@ const BasicInput = ({
   const { isError, handleInput } = useInput({ inputRef, regExp });
 
   return (
-    <>
-      {label === 'search' ? (
-        <SearchTextFieldStyled
-          type="search"
-          variant="filled"
-          hiddenLabel
-          onChange={handleInput}
-          required={isRequired}
-          name={label}
-          placeholder="검색어를 입력해주세요"
-          fullWidth
-        />
-      ) : (
-        <TextField
-          onChange={handleInput}
-          required={isRequired}
-          name={label}
-          label={label}
-          defaultValue={defaultValue}
-          type={type}
-          error={isError}
-          helperText={isError ? errorMessage : ''}
-          multiline={type === 'multiline'}
-          fullWidth
-        />
-      )}
-    </>
+    <TextField
+      onChange={handleInput}
+      required={isRequired}
+      name={label}
+      label={label}
+      defaultValue={defaultValue}
+      type={type}
+      error={isError}
+      helperText={isError ? errorMessage : ''}
+      multiline={type === 'multiline'}
+      fullWidth
+    />
   );
 };
-
-const SearchTextFieldStyled = styled(TextField)({
-  borderRadius: '20px;',
-  overflow: 'hidden',
-});
 
 export default BasicInput;

--- a/src/components/shared/search/index.tsx
+++ b/src/components/shared/search/index.tsx
@@ -4,7 +4,7 @@ import TextField from '@mui/material/TextField';
 import useInput from '@/hooks/components/useInput';
 import { BasicInputProps } from '@/types/components/BasicInputProps';
 
-const BasicSearch = ({ inputRef }: Partial<BasicInputProps>) => {
+const BasicSearch = ({ inputRef }: Partial<BasicInputProps<string>>) => {
   const { handleInput } = useInput({ inputRef });
 
   return (

--- a/src/components/shared/search/index.tsx
+++ b/src/components/shared/search/index.tsx
@@ -1,0 +1,29 @@
+import styled from '@emotion/styled';
+import TextField from '@mui/material/TextField';
+
+import useInput from '@/hooks/components/useInput';
+import { BasicInputProps } from '@/types/components/BasicInputProps';
+
+const BasicSearch = ({ inputRef }: Partial<BasicInputProps>) => {
+  const { handleInput } = useInput({ inputRef });
+
+  return (
+    <SearchTextFieldStyled
+      type="search"
+      variant="filled"
+      hiddenLabel
+      onChange={handleInput}
+      required
+      name="search"
+      placeholder="검색어를 입력해주세요"
+      fullWidth
+    />
+  );
+};
+
+const SearchTextFieldStyled = styled(TextField)({
+  borderRadius: '20px;',
+  overflow: 'hidden',
+});
+
+export default BasicSearch;

--- a/src/hooks/components/useInput.ts
+++ b/src/hooks/components/useInput.ts
@@ -2,7 +2,7 @@ import { useState } from 'react';
 
 import { BasicInputProps } from '@/types/components/BasicInputProps';
 
-const useInput = ({ inputRef, regExp }: Partial<BasicInputProps>) => {
+const useInput = <T>({ inputRef, regExp }: Partial<BasicInputProps<T>>) => {
   const [isError, setIsError] = useState(false);
 
   const handleInput = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/hooks/components/useInput.ts
+++ b/src/hooks/components/useInput.ts
@@ -1,11 +1,8 @@
-import { useState, MutableRefObject } from 'react';
+import { useState } from 'react';
 
-interface Props {
-  inputRef: MutableRefObject<object>;
-  regExp?: string;
-}
+import { BasicInputProps } from '@/types/components/BasicInputProps';
 
-const useInput = ({ inputRef, regExp }: Props) => {
+const useInput = ({ inputRef, regExp }: Partial<BasicInputProps>) => {
   const [isError, setIsError] = useState(false);
 
   const handleInput = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -15,7 +12,9 @@ const useInput = ({ inputRef, regExp }: Props) => {
       setIsError(!new RegExp(regExp).test(value));
     }
 
-    inputRef.current = { ...inputRef.current, [name]: value };
+    if (inputRef) {
+      inputRef.current = { ...inputRef.current, [name]: value };
+    }
   };
 
   return { isError, handleInput };

--- a/src/hooks/components/useInput.ts
+++ b/src/hooks/components/useInput.ts
@@ -1,0 +1,24 @@
+import { useState, MutableRefObject } from 'react';
+
+interface Props {
+  inputRef: MutableRefObject<object>;
+  regExp?: string;
+}
+
+const useInput = ({ inputRef, regExp }: Props) => {
+  const [isError, setIsError] = useState(false);
+
+  const handleInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.currentTarget;
+
+    if (regExp) {
+      setIsError(!new RegExp(regExp).test(value));
+    }
+
+    inputRef.current = { ...inputRef.current, [name]: value };
+  };
+
+  return { isError, handleInput };
+};
+
+export default useInput;

--- a/src/types/components/BasicInputProps.ts
+++ b/src/types/components/BasicInputProps.ts
@@ -1,0 +1,11 @@
+import { MutableRefObject } from 'react';
+
+export interface BasicInputProps {
+  type?: string;
+  label: string;
+  isRequired?: boolean;
+  defaultValue?: string;
+  regExp?: string;
+  errorMessage?: string;
+  inputRef: MutableRefObject<object>;
+}

--- a/src/types/components/BasicInputProps.ts
+++ b/src/types/components/BasicInputProps.ts
@@ -1,11 +1,11 @@
 import { MutableRefObject } from 'react';
 
-export interface BasicInputProps {
+export interface BasicInputProps<T> {
   type?: string;
   label: string;
   isRequired?: boolean;
   defaultValue?: string;
   regExp?: string;
   errorMessage?: string;
-  inputRef: MutableRefObject<object>;
+  inputRef: MutableRefObject<T>;
 }


### PR DESCRIPTION
## 기능 이름
BasicInput 컴포넌트
BasicSearch 컴포넌트

## 기능 설명

### BasicInput 컴포넌트
: login, sign up, post 등에서 사용되는 input 컴포넌트입니다.
- 사용방법
 ```tsx
// sign up 시 아이디 input
  <BasicInput
    type="search" // BasicInput에서는 type='search'를 해줘야 x 버튼(입력지우기)이 생깁니다.
    label="email" // label은 사용자에게 보일 입력칸의 이름을 나타냅니다.
    isRequired={true} // isRequired가 true이면 입력이 없을 때 form을 제출할 수 없습니다.
    regExp={'[a-z0-9]+@[a-z]+.[a-z]{2,3}'} // signup의 경우 정규식을 입력해줘야합니다.
    errorMessage="도메인을 입력해주세요" // 정규식 일치x에 따른 메세지를 지정해줍니다.
    inputRef={inputObjectRef} // 값을 저장할 ref입니다.
  />
// login 시 password input
  <BasicInput
    type="password"
    label="password"
    isRequired={true}
    regExp={'^(?=.*[a-zA-Z])(?=.*[0-9]).{8,25}$'}
    errorMessage="영문 숫자 조합 8자리 이상 입력해주세요"
    inputRef={inputObjectRef}
  />
  <BasicInput label="자기소개" type="multiline" inputRef={inputObjectRef} /> // 여러 줄을 입력해야하는 경우 type="multiline"을 지정해줘야 합니다.
```
- props 설명
    - `인자 : 타입; - default value`
    - `type?: string; - search` 
         -  x버튼을 넣기 위해 `search`를 기본값으로 세팅해두었습니다.  상황에 따라 `multiline`,`password`을 이용해주세요.
    - `label: string; - x`
         - 사용자에게 보일 입력칸의 이름
     - `isRequired?: boolean- true;` 
           -  true(form을 제출x), false(옵션, 쓰든 안 쓰든 상관x)
     - `defaultValue?: string- x;`
     - `regExp?: string;- x`
             - signup 시 사용되는 정규식
    - `errorMessage?: string- x;`
               - 정규식 test 틀리면 보이는 메세지
     - `inputRef: MutableRefObject<object>- x;`
              - 값을 저장할 ref(object 타입)

### BasicSearch 컴포넌트 
: 헤더의 검색바에서 사용되는 input 컴포넌트입니다.
- 사용방법
```tsx
<BasicSearch inputRef={inputStringRef} />
```
- props 설명
    - `인자 : 타입; - default value`
    - `inputRef: MutableRefObject<string>- x;`
         - 값을 저장할 ref(string 타입)

<details>
<summary><h3>전체 코드 보기</h3></summary>
<div markdown="1">

```tsx
import { useRef } from 'react';

import BasicInput from '@/components/shared/input';
import BasicSearch from '@/components/shared/search';

export default function HomePage() {
  const inputObjectRef = useRef({});
  const inputStringRef = useRef('');

  const handleFormSubmit = (e: React.ChangeEvent<HTMLFormElement>) => {
    e.preventDefault();
    // inputRef.current에 대한 조작
    console.log(inputObjectRef.current);
    console.log(inputStringRef.current);
  };

  return ( 
      <form onSubmit={handleFormSubmit}>
        <BasicInput
          type="search"
          label="email"
          isRequired={true}
          regExp={'[a-z0-9]+@[a-z]+.[a-z]{2,3}'}
          errorMessage="도메인을 입력해주세요"
          inputRef={inputObjectRef}
        />
        <BasicInput
          type="password"
          label="password"
          isRequired={true}
          regExp={'^(?=.*[a-zA-Z])(?=.*[0-9]).{8,25}$'}
          errorMessage="영문 숫자 조합 8자리 이상 입력해주세요"
          inputRef={inputObjectRef}
        />
        <BasicInput
          label="자기소개"
          type="multiline"
          inputRef={inputObjectRef}
        />

        <BasicSearch inputRef={inputStringRef} />
        <button type="submit">제출</button>
      </form> 
  );
} 
```

</div>
</details>




## 구현 내용
<!-- ## 스크린샷 - UI 관련인 경우 꼭 넣기! -->
<!-- ## 장애물 - 기능 구현 중 있었던 이슈 --> 
 
![image](https://github.com/prgrms-fe-devcourse/FEDC4_CUCUMIS_Pocojang/assets/87280835/14a9b84a-e072-4dec-9254-5552c00ed857)


## PR 포인트
<!--리뷰어가 집중했으면 하는 부분 -->  


## 참고 사항
<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->  
- BasicInput으로 모든 input을 다루려다 사용하기 편하도록 BasicInput과 BasicSearch를 분리했습니다.
- 공통의 interface(BasicInputProps<T>)와 hook(useInput)은 각각 `types/components/BasicInputProps`와 hooks/components/useInput`에 저장하고 있습니다.
- 렌더링을 막기 위해 useRef로 input 값을 다루고 있습니다.
## 궁금한 점
<!-- ## 이슈 번호 - close -->
<!--## 완료 사항-->  

