### PR TITLE
기본 버튼 구현

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
   "semi": true,
-  "singleQuote": true
+  "singleQuote": true,
+  "endOfLine": "lf"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
+        "@mui/icons-material": "^5.14.8",
         "@mui/material": "^5.14.7",
         "@reduxjs/toolkit": "^1.9.5",
         "axios": "^1.5.0",
@@ -819,6 +820,31 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui"
+      }
+    },
+    "node_modules/@mui/icons-material": {
+      "version": "5.14.8",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.14.8.tgz",
+      "integrity": "sha512-YXcReLydTuNWb1/PxduAH5LgnHNH6spSQBaA0JOz9HD4J+vwst0IanAQgsXy9KKCJSjCsHywE3DB8X+w/b4eeQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.10"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@mui/material": "^5.0.0",
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@mui/material": {

--- a/package.json
+++ b/package.json
@@ -17,8 +17,9 @@
   "dependencies": {
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
+    "@mui/icons-material": "^5.14.8",
     "@mui/material": "^5.14.7",
-"@reduxjs/toolkit": "^1.9.5",
+    "@reduxjs/toolkit": "^1.9.5",
     "axios": "^1.5.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/components/shared/button/index.tsx
+++ b/src/components/shared/button/index.tsx
@@ -2,25 +2,11 @@ import Button, { ButtonProps } from '@mui/material/Button';
 
 interface Props extends ButtonProps {
   children: React.ReactNode;
-  name: string;
-  onClick: () => void;
 }
 
-const BasicButton = ({
-  variant = 'contained',
-  name,
-  onClick,
-  children,
-  ...props
-}: Props) => {
+const BasicButton = ({ variant = 'contained', children, ...props }: Props) => {
   return (
-    <Button
-      fullWidth
-      variant={variant}
-      name={name}
-      onClick={onClick}
-      {...props}
-    >
+    <Button fullWidth variant={variant} {...props}>
       {children}
     </Button>
   );

--- a/src/components/shared/button/index.tsx
+++ b/src/components/shared/button/index.tsx
@@ -11,4 +11,5 @@ const BasicButton = ({ variant = 'contained', children, ...props }: Props) => {
     </Button>
   );
 };
+
 export default BasicButton;

--- a/src/components/shared/button/index.tsx
+++ b/src/components/shared/button/index.tsx
@@ -4,9 +4,14 @@ interface Props extends ButtonProps {
   children: React.ReactNode;
 }
 
-const BasicButton = ({ variant = 'contained', children, ...props }: Props) => {
+const BasicButton = ({
+  variant = 'contained',
+  color = 'primary',
+  children,
+  ...props
+}: Props) => {
   return (
-    <Button fullWidth variant={variant} {...props}>
+    <Button fullWidth color={color} variant={variant} {...props}>
       {children}
     </Button>
   );

--- a/src/components/shared/button/index.tsx
+++ b/src/components/shared/button/index.tsx
@@ -1,0 +1,28 @@
+import Button, { ButtonProps } from '@mui/material/Button';
+
+interface Props extends ButtonProps {
+  children: React.ReactNode;
+  name: string;
+  onClick: () => void;
+}
+
+const BasicButton = ({
+  variant = 'contained',
+  name,
+  onClick,
+  children,
+  ...props
+}: Props) => {
+  return (
+    <Button
+      fullWidth
+      variant={variant}
+      name={name}
+      onClick={onClick}
+      {...props}
+    >
+      {children}
+    </Button>
+  );
+};
+export default BasicButton;

--- a/src/components/shared/iconButton/index.tsx
+++ b/src/components/shared/iconButton/index.tsx
@@ -1,8 +1,11 @@
 import IconButton, { IconButtonProps } from '@mui/material/IconButton';
+import SvgIcon from '@mui/material/SvgIcon';
 
 interface Props extends IconButtonProps {
-  children: React.ReactNode;
+  children: React.ReactElement<SvgIconComponent>;
 }
+
+type SvgIconComponent = typeof SvgIcon;
 
 const BasicIconButton = ({ children, color = 'primary', ...props }: Props) => {
   return (

--- a/src/components/shared/iconButton/index.tsx
+++ b/src/components/shared/iconButton/index.tsx
@@ -3,6 +3,7 @@ import IconButton, { IconButtonProps } from '@mui/material/IconButton';
 interface Props extends IconButtonProps {
   children: React.ReactNode;
 }
+
 const BasicIconButton = ({ children, color = 'primary', ...props }: Props) => {
   return (
     <IconButton color={color} {...props}>

--- a/src/components/shared/iconButton/index.tsx
+++ b/src/components/shared/iconButton/index.tsx
@@ -1,0 +1,14 @@
+import IconButton, { IconButtonProps } from '@mui/material/IconButton';
+
+interface Props extends IconButtonProps {
+  children: React.ReactNode;
+}
+const BasicIconButton = ({ children, color = 'primary', ...props }: Props) => {
+  return (
+    <IconButton color={color} {...props}>
+      {children}
+    </IconButton>
+  );
+};
+
+export default BasicIconButton;


### PR DESCRIPTION
## 기능 이름
BasicButtonComponent
BasicIconButton
## 기능 설명
기본 버튼으로 children 넣어서 사용하시면 됩니다. 그리고 기본적으로 가로 크기에 꽉 차도록 설정되었습니다. 
iconButton도 children 넣어서 사용하면 됩니다. 
## 구현 내용
<!-- ## 스크린샷 - UI 관련인 경우 꼭 넣기! -->
<!-- ## 장애물 - 기능 구현 중 있었던 이슈 -->  
![스크린샷 2023-09-08 141803](https://github.com/prgrms-fe-devcourse/FEDC4_CUCUMIS_Pocojang/assets/61609327/b740a835-eb74-4f50-bed1-cf2b9135a338)
![image](https://github.com/prgrms-fe-devcourse/FEDC4_CUCUMIS_Pocojang/assets/61609327/edaf62af-0bcb-42a4-aefb-867535187405)



## PR 포인트
<!--리뷰어가 집중했으면 하는 부분 -->  


## 참고 사항
<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->  


## 궁금한 점
<!-- ## 이슈 번호 - close -->
<!--## 완료 사항-->  
- close #27 