### PR TITLE
feature/fab 위치 수정 기능 추가 

### DIFF
--- a/src/components/shared/fab/index.tsx
+++ b/src/components/shared/fab/index.tsx
@@ -1,23 +1,54 @@
 import Fab, { FabProps } from '@mui/material/Fab';
+import { Box } from '@mui/material';
 import styled from '@emotion/styled';
 
 interface Props extends FabProps {
+  bottom?: number;
+  right?: number;
   children: React.ReactNode;
   onClick: () => void;
 }
 
-const BasicFab = ({ children, onClick, ...props }: Props) => {
+const BasicFab = ({
+  bottom = 80,
+  right = 20,
+  children,
+  onClick,
+  ...props
+}: Props) => {
   return (
-    <FixedFab color="primary" onClick={onClick} {...props}>
-      {children}
-    </FixedFab>
+    <BoxStyled>
+      <FabStyled
+        bottom={bottom}
+        right={right}
+        color="primary"
+        onClick={onClick}
+        {...props}
+      >
+        {children}
+      </FabStyled>
+    </BoxStyled>
   );
 };
 
-const FixedFab = styled(Fab)(() => ({
-  position: 'fixed',
-  bottom: '10px',
-  right: '10px',
-}));
+const FabStyled = styled(Fab)<{ bottom: number; right: number }>(
+  ({ bottom, right }) => ({
+    position: 'absolute',
+    bottom: `${bottom}px`,
+    right: `${right}px`,
+    pointerEvents: 'auto',
+  }),
+);
 
+const BoxStyled = styled(Box)({
+  zIndex: '10',
+  maxWidth: '600px',
+  bottom: '0',
+  width: '100%',
+  height: 'calc(100vh - 80px)',
+  position: 'fixed',
+  left: '50%',
+  transform: 'translate(-50%)',
+  pointerEvents: 'none',
+});
 export default BasicFab;


### PR DESCRIPTION
## 기능 이름
fab 위치 수정 기능

## 기능 설명
fab 사용 시 기존에는 위치를 고정했지만 페이지에 따라서 위치가 조정이 가능하도록 바꾸었습니다. 
레이어를 만들어서 그 안에 버튼이 위치하도록 했고 레이어는 fixed로 화면에 고정됩니다. 
## 구현 내용
<!-- ## 스크린샷 - UI 관련인 경우 꼭 넣기! -->
<!-- ## 장애물 - 기능 구현 중 있었던 이슈 -->  
- 사용방법
    
    ```tsx
    <BasicFab 
    bottom={20} //화면 기준 아래에서 20px위에 위치
    	right={20} //화면 기준 우측에서 20px 좌측에 위치
    onClick={()=>{}} // 사용할 함수를 onClic으로 바인딩해줍니다. 
    >
    children // 버튼안에서 보여줄 Icon이나 글자를 넣어주면 됩니다. 
    </BasicFab>
    ```
- props 설명
    - 인자 : 타입; -default Value
    - bottom:number; -80
        - 화면 아래 기준으로 위치합니다.
    - right: number; - 20
        - 화면 우측 기준으로 위치합니다.
    - onClick: ()⇒void; -x
        - 버튼 클릭시 작동시킬 함수입니다.
    - childre: React.ReactNode; -x
        - 버튼 안에서 보여줄 아이콘, 글자
     
## PR 포인트
<!--리뷰어가 집중했으면 하는 부분 -->  


## 참고 사항
<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->  


## 궁금한 점
<!-- ## 이슈 번호 - close -->
<!--## 완료 사항-->  
- close #67
