### PR TITLE
infiniteScroll hook 추가

### DIFF
--- a/src/hooks/useInfiniteScroll.ts
+++ b/src/hooks/useInfiniteScroll.ts
@@ -1,0 +1,64 @@
+import { useEffect, useState, useMemo, useRef, MutableRefObject } from 'react';
+
+export interface InfiniteScrollProps {
+  target: MutableRefObject<HTMLDivElement | null>;
+  targetArray: Array<unknown>;
+  endPoint?: number;
+  options: IntersectionObserverOptions;
+}
+
+export interface IntersectionObserverOptions {
+  root?: Element | null;
+  rootMargin?: string;
+  threshold?: number;
+}
+
+const useInfiniteScroll = ({
+  target,
+  targetArray,
+  endPoint = 1,
+  options: { root = null, rootMargin = '0px', threshold = 1 },
+}: InfiniteScrollProps) => {
+  const [page, setPage] = useState<number>(0);
+  const currentChild = useRef<Element | null>(null);
+
+  const observer = useMemo(() => {
+    return new IntersectionObserver(
+      (entries, observer) => {
+        if (target?.current === null) return;
+
+        if (entries[0].isIntersecting) {
+          setPage((v) => v + 1);
+          observer.disconnect();
+        }
+      },
+      { root, rootMargin, threshold },
+    );
+  }, [target, root, rootMargin, threshold]);
+
+  useEffect(() => {
+    if (target?.current === null) return;
+
+    const observeChild =
+      target.current.children[target.current.children.length - endPoint];
+    if (observeChild && currentChild.current !== observeChild) {
+      currentChild.current = observeChild;
+      observer.observe(observeChild);
+    }
+
+    return () => {
+      const { current } = target;
+
+      if (current !== null && observer) {
+        observer.unobserve(current);
+      }
+    };
+  }, [page, target, targetArray, observer, endPoint]);
+
+  return {
+    page,
+    setPage,
+  };
+};
+
+export default useInfiniteScroll;

--- a/src/hooks/useInfiniteScroll.ts
+++ b/src/hooks/useInfiniteScroll.ts
@@ -2,7 +2,6 @@ import { useEffect, useState, useMemo, useRef, MutableRefObject } from 'react';
 
 export interface InfiniteScrollProps {
   target: MutableRefObject<HTMLDivElement | null>;
-  targetArray: Array<unknown>;
   endPoint?: number;
   options: IntersectionObserverOptions;
 }
@@ -15,7 +14,6 @@ export interface IntersectionObserverOptions {
 
 const useInfiniteScroll = ({
   target,
-  targetArray,
   endPoint = 1,
   options: { root = null, rootMargin = '0px', threshold = 1 },
 }: InfiniteScrollProps) => {
@@ -39,8 +37,9 @@ const useInfiniteScroll = ({
   useEffect(() => {
     if (target?.current === null) return;
 
-    const observeChild =
-      target.current.children[target.current.children.length - endPoint];
+    const { current } = target;
+
+    const observeChild = current.children[current.children.length - endPoint];
     if (observeChild && currentChild.current !== observeChild) {
       currentChild.current = observeChild;
       observer.observe(observeChild);
@@ -53,7 +52,7 @@ const useInfiniteScroll = ({
         observer.unobserve(current);
       }
     };
-  }, [page, target, targetArray, observer, endPoint]);
+  }, [page, target, observer, endPoint]);
 
   return {
     page,


### PR DESCRIPTION
## 기능 이름
무한 스크롤 hook 을 만들었습니다.

## 기능 설명
target 의 끝에서 endPoint 까지 item 을 지날때, api fetch 를 수행할 수 있도록 도와주는 무한 스크롤 API 입니다
API 를 제대로 사용할 수가 없어서, 잘 동작하는지 테스트하기가 어렵네요...!
사용하시다가 문제 발생시 공유해주세요..!

### 사용방법
다음과 같이 useInfiniteScroll hook 을 사용할 수 있습니다.
(예시 코드이므로, 실제로는 동작하지 않을 수도 있습니다)
```typescript
import { useEffect, useRef, useState } from 'react';

import useInfiniteScroll from '@/hooks/useInfiniteScroll';

const usePosts = () => {
  const target = useRef<HTMLDivElement>(null);
  const [isLoading, setIsLoading] = useState<boolean>(true);
  const [postList, setPostList] = useState<PostType[]>([]);

  const { page } = useInfiniteScroll({
    target: target,
    endPoint: 3,
    options: { threshold: 0.2 },
  });

  useEffect(() => {
    setIsLoading(true);
    console.log('setPostList', page);
    const offset = page * 10;
    const limit = 10;

    // API fetch
    const { posts } = getPosts({ offset, limit });
    setPostList([...postList, ...posts]);

    setIsLoading(false);
  }, [page, postList]);

  return {
    postList,
    target,
    isLoading,
  };
};

export default usePosts;
```

Infinity Scroll 을 적용해야하는 리스트에 꼭 ref 로 target 을 넣어주어야 합니다!
```typescript
const PostsPage = () => {
  const { postList, target, isLoading } = usePosts();
  return (
    <Stack spacing={2} ref={target}>
      {postList.map((post) => (
        <PostItem value={post} />
      ))}
    </Stack>
  );
};
```

## 구현 내용
<!-- ## 스크린샷 - UI 관련인 경우 꼭 넣기! -->
<!-- ## 장애물 - 기능 구현 중 있었던 이슈 -->  
`Intersection Observer` 를 사용하여 구현헀습니다!
빠르게 구현하려다보니, 제가 `Intersection Observer`를 제대로 이해하고 사용하지 못해서(기술부채ㅎㅎ)
추후 문제가 생기면 리팩토링이 필요할 것 같습니다..!

## PR 포인트
<!--리뷰어가 집중했으면 하는 부분 -->  
혹시 제가 IntersectionObserver 를 잘못 사용했거나, 어색하게 사용한 부분이 있다면, 꼭 리뷰 남겨주세요!

## 참고 사항
<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->  


## 궁금한 점
<!-- ## 이슈 번호 - close -->
<!--## 완료 사항-->  

