### PR TITLE
Feature/110 layoutstore input useform

### DIFF
--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -11,7 +11,7 @@ import { useAppDispatch, useAppSelector } from '@/stores/hooks';
 import { setInput, headerTypeSelector, titleSelector } from '@/stores/layout';
 import { isLoginSelector } from '@/stores/auth';
 import { HeaderType, Title } from '@/types/components/Header';
-import useForm from '@/hooks/useForm';
+import useForm, { FormErrors, FormValues } from '@/hooks/useForm';
 import BasicChip from '@/components/shared/chip';
 import BasicSearch from '@/components/shared/search';
 import BasicIconButton from '@/components/shared/iconButton';
@@ -22,13 +22,13 @@ const Header = () => {
   const headerType = useAppSelector(headerTypeSelector);
   const title = useAppSelector(titleSelector);
   const isLogin = useAppSelector(isLoginSelector);
-  const { handleChange, handleSubmit } = useForm({
+  const { values, handleChange, handleSubmit } = useForm({
     initialValues: { search: '' },
-    onSubmit: ({ search }) => {
+    onSubmit: ({ search }: FormValues) => {
       dispatch(setInput(search));
     },
-    validate: ({ search }) => {
-      const newErrors = { search: '' };
+    validate: ({ search }: FormValues) => {
+      const newErrors: FormErrors = {};
       if (!search) newErrors.search = '검색어를 입력해주세요.';
       return newErrors;
     },
@@ -78,6 +78,7 @@ const Header = () => {
             </LinkStyled>
             <FormStyled onSubmit={handleSubmit}>
               <BasicSearch
+                value={values.search}
                 onChange={handleChange}
                 placeholder="검색어를 입력해주세요"
               />

--- a/src/components/navbar/index.tsx
+++ b/src/components/navbar/index.tsx
@@ -13,7 +13,7 @@ import SendIcon from '@mui/icons-material/Send';
 import { useAppDispatch, useAppSelector } from '@/stores/hooks';
 import { setInput, locationSelector } from '@/stores/layout';
 import { userIdSelector } from '@/stores/auth';
-import useForm from '@/hooks/useForm';
+import useForm, { FormValues, FormErrors } from '@/hooks/useForm';
 import BasicSearch from '@/components/shared/search';
 import BasicIconButton from '@/components/shared/iconButton';
 
@@ -24,13 +24,13 @@ const Navbar = () => {
   const path = useAppSelector(locationSelector)
     .split('/')
     .filter((path) => path);
-  const { handleChange, handleSubmit } = useForm({
+  const { values, handleChange, handleSubmit } = useForm({
     initialValues: { search: '' },
-    onSubmit: ({ search }) => {
+    onSubmit: ({ search }: FormValues) => {
       dispatch(setInput(search));
     },
-    validate: ({ search }) => {
-      const newErrors = { search: '' };
+    validate: ({ search }: FormValues) => {
+      const newErrors: FormErrors = {};
       if (!search) newErrors.search = '내용을 입력해주세요.';
       return newErrors;
     },
@@ -68,6 +68,7 @@ const Navbar = () => {
           <FormStyled onSubmit={handleSubmit}>
             <BasicSearch
               onChange={handleChange}
+              value={values.search}
               placeholder="내용을 입력해주세요"
             />
             <BasicIconButton type="submit">

--- a/src/hooks/useForm.ts
+++ b/src/hooks/useForm.ts
@@ -44,11 +44,13 @@ const useForm = ({ initialValues, onSubmit, validate }: FormProps) => {
     } catch (error) {
       console.error(error);
     } finally {
+      setValues(initialValues);
       setIsLoading(false);
     }
   };
 
   return {
+    values,
     errors,
     isLoading,
     handleChange,

--- a/src/stores/layout/index.ts
+++ b/src/stores/layout/index.ts
@@ -6,6 +6,7 @@ export const { setLocation, setInput } = layoutSlice.actions;
 export const {
   layoutSelector,
   locationSelector,
+  inputSelector,
   headerTypeSelector,
   titleSelector,
 } = selector;

--- a/src/stores/layout/selector.ts
+++ b/src/stores/layout/selector.ts
@@ -8,6 +8,7 @@ import { isLoginSelector, userIdSelector } from '@/stores/auth';
 export const layoutSelector = (state: RootState): LayoutState => state.layout;
 export const locationSelector = (state: RootState): string =>
   state.layout.location;
+export const inputSelector = (state: RootState): string => state.layout.input;
 
 export const headerTypeSelector = createSelector(
   locationSelector,


### PR DESCRIPTION
## 기능 이름
layoutStore input state와 useForm 연결 수정

## 기능 설명
- layoutStore input state와 useForm 연결을 수정했습니다.
  - submit 시 `values: initialState`로 초기화
  - useForm `values` return 추가
- layoutStore input selector를 추가했습니다.

## 구현 내용
https://github.com/prgrms-fe-devcourse/FEDC4_CUCUMIS_Pocojang/assets/49032882/b91cc3b1-46ae-4747-b477-b196c6878a1a

## PR 포인트
- Header, Navbar 이벤트에 따라 layoutStore input state 변화가 적절한지 봐주시면 감사하겠습니다.
- useForm 수정했는데 다른 부분에 영향이 없을까요?

## 참고 사항

## 궁금한 점
<!-- ## 이슈 번호 - close -->
<!--## 완료 사항-->  

