### PR TITLE
Feature/89 dm list page

### DIFF
--- a/src/components/dm/useDMDetail.ts
+++ b/src/components/dm/useDMDetail.ts
@@ -38,15 +38,16 @@ export const useDMDetail = ({
     async (dmUserId: string) => {
       try {
         const responseMessages = await getMessages({ userId: dmUserId });
-        if (responseMessages.length > messages.length) {
-          dispatch(setMessages(responseMessages));
-        }
+        const sortedMessages = responseMessages.sort(
+          (a, b) => +new Date(a.createdAt) - +new Date(b.createdAt),
+        );
+        dispatch(setMessages(sortedMessages));
       } catch (error) {
         // TODO: message 불러오기 실패
         onGetFail(error);
       }
     },
-    [messages, dispatch, onGetFail],
+    [dispatch, onGetFail],
   );
 
   const fetchVisitingUser = useCallback(

--- a/src/components/dm/useDMDetail.ts
+++ b/src/components/dm/useDMDetail.ts
@@ -5,13 +5,8 @@ import { getMessages, sendMessage } from '@/api/messages';
 import { RequestSendMessagesType } from '@/types/api/messages';
 import { useAppDispatch, useAppSelector } from '@/stores/hooks';
 import { userIdSelector } from '@/stores/auth';
+import { inputSelector, setVisitingUser } from '@/stores/layout';
 import {
-  locationSelector,
-  inputSelector,
-  setVisitingUser,
-} from '@/stores/layout';
-import {
-  setDMUserId,
   setMessages,
   addMessage,
   dmUserIdSelector,
@@ -29,7 +24,6 @@ export const useDMDetail = ({
   onSendFail,
 }: DMDetailHookParameters) => {
   const dispatch = useAppDispatch();
-  const location = useAppSelector(locationSelector);
   const userId = useAppSelector(userIdSelector);
   const input = useAppSelector(inputSelector);
   const dmUserId = useAppSelector(dmUserIdSelector);
@@ -39,10 +33,6 @@ export const useDMDetail = ({
   }));
   const messageEndRef = useRef<HTMLDivElement | null>(null);
   const [isLoading, setIsLoading] = useState(true);
-
-  useEffect(() => {
-    dispatch(setDMUserId(location.split('/')[2]));
-  }, [dispatch, location]);
 
   const fetchMessages = useCallback(
     async (dmUserId: string) => {

--- a/src/components/dm/useDMDetail.ts
+++ b/src/components/dm/useDMDetail.ts
@@ -65,7 +65,7 @@ export const useDMDetail = ({
     [dispatch, onGetFail],
   );
 
-  const fetchMessagesSeen = useCallback(
+  const updateMessagesSeen = useCallback(
     async (dmUserId: string) => {
       try {
         await readMessages({ sender: dmUserId });
@@ -84,14 +84,20 @@ export const useDMDetail = ({
     if (dmUserId) {
       fetchMessages(dmUserId);
       fetchVisitingUser(dmUserId);
-      fetchMessagesSeen(dmUserId);
+      updateMessagesSeen(dmUserId);
     }
-  }, [dmUserId, dispatch, fetchMessages, fetchVisitingUser, fetchMessagesSeen]);
+  }, [
+    dmUserId,
+    dispatch,
+    fetchMessages,
+    fetchVisitingUser,
+    updateMessagesSeen,
+  ]);
 
   useInterval(() => {
     if (dmUserId) {
       fetchMessages(dmUserId);
-      fetchMessagesSeen(dmUserId);
+      updateMessagesSeen(dmUserId);
     }
   }, 3000);
 

--- a/src/components/dm/useDMList.ts
+++ b/src/components/dm/useDMList.ts
@@ -47,7 +47,7 @@ export const useDMList = ({ onFail }: DMListHookParameters) => {
       );
       Promise.all(requests)
         .then((results) => {
-          const finishedConversations = results.map((result) => {
+          const unReadCountedConversations = results.map((result) => {
             const conversationUser = [result[0].receiver, result[0].sender];
             const dmUser = conversationUser.find((user) => user._id !== userId);
             const conversationIndex = conversations.findIndex(
@@ -60,7 +60,7 @@ export const useDMList = ({ onFail }: DMListHookParameters) => {
             return { ...conversations[conversationIndex], unReadCount };
           });
 
-          dispatch(setConversations(finishedConversations));
+          dispatch(setConversations(unReadCountedConversations));
         })
         .catch((error) => onFail(error));
     },

--- a/src/components/dm/useDMList.ts
+++ b/src/components/dm/useDMList.ts
@@ -1,62 +1,80 @@
+import { useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-export const useDMList = () => {
+import { getConversations, getMessages } from '@/api/messages';
+import { useAppDispatch, useAppSelector } from '@/stores/hooks';
+import { setConversations, conversationsSelector } from '@/stores/dm';
+import { userIdSelector } from '@/stores/auth';
+import { setVisitingUser } from '@/stores/layout';
+import { ConversationDataType } from '@/stores/dm/slice';
+import { UserType } from '@/types';
+
+interface DMListHookParameters {
+  onFail: (error: unknown) => void;
+}
+
+export const useDMList = ({ onFail }: DMListHookParameters) => {
   const navigate = useNavigate();
+  const dispatch = useAppDispatch();
+  const userId = useAppSelector(userIdSelector);
+  const conversations = useAppSelector(conversationsSelector);
+  const [isLoading, setIsLoading] = useState(true);
 
-  const conversations = [
-    {
-      _id: '1',
-      AvatarProps: {
-        onClick: () => navigate('/profile/user1'),
-        isUserOn: true,
-      },
-      name: 'user1',
-      message: 'Hello, World! 🤗',
-      to: 'user1',
-      unReadCount: 1000,
-    },
-    {
-      _id: '2',
-      AvatarProps: {
-        onClick: () => navigate('/profile/user2'),
-      },
-      name: 'user2',
-      message: 'Hi!',
-      to: 'user2',
-      unReadCount: 1001,
-    },
-    {
-      _id: '3',
-      AvatarProps: {
-        onClick: () => navigate('/profile/user3'),
-        isUserOn: true,
-      },
-      name: 'user3',
-      message: '같이 프로젝트 진행하고 싶습니다!',
-      to: 'user3',
-      unReadCount: 0,
-    },
-    {
-      _id: '4',
-      AvatarProps: {
-        onClick: () => navigate('/profile/user4'),
-      },
-      name: 'user4',
-      message: '감사합니다!',
-      to: 'user4',
-      unReadCount: 0,
-    },
-    {
-      _id: '5',
-      AvatarProps: {
-        onClick: () => navigate('/profile/user5'),
-      },
-      name: 'user5',
-      message: '안녕하세요 :)',
-      to: 'user5',
-      unReadCount: 1,
-    },
-  ];
+  const fetchConversations = useCallback(async () => {
+    try {
+      const responseConversations = await getConversations();
+      const filteredConversations = responseConversations
+        .filter((conversation) => conversation._id.some((id) => id !== userId))
+        .map((conversation) => {
+          const conversationUser = [conversation.receiver, conversation.sender];
+          const dmUser = conversationUser.find((user) => user._id !== userId);
+          return { ...conversation, dmUser, unReadCount: -1 };
+        });
 
-  return { conversations };
+      dispatch(setConversations(filteredConversations));
+      return filteredConversations;
+    } catch (error) {
+      onFail(error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [dispatch, userId, onFail]);
+
+  const fetchUnReadCounts = useCallback(
+    async (conversations: ConversationDataType[]) => {
+      const requests = conversations.map((conversation) =>
+        getMessages({ userId: conversation.dmUser?._id ?? '' }),
+      );
+      Promise.all(requests)
+        .then((results) => {
+          const finishedConversations = results.map((result) => {
+            const conversationUser = [result[0].receiver, result[0].sender];
+            const dmUser = conversationUser.find((user) => user._id !== userId);
+            const conversationIndex = conversations.findIndex(
+              (conversation) => conversation.dmUser?._id === dmUser?._id,
+            );
+            const unReadCount = result.filter(
+              (message) => message.receiver._id === userId && !message.seen,
+            ).length;
+
+            return { ...conversations[conversationIndex], unReadCount };
+          });
+
+          dispatch(setConversations(finishedConversations));
+        })
+        .catch((error) => onFail(error));
+    },
+    [dispatch, userId, onFail],
+  );
+
+  useEffect(() => {
+    fetchConversations().then((result) => result && fetchUnReadCounts(result));
+  }, [dispatch, fetchConversations, fetchUnReadCounts]);
+
+  const handleConversationClick = (dmUser: UserType) => {
+    navigate(`/dm/${dmUser._id}`);
+    dispatch(setVisitingUser(dmUser));
+  };
+
+  return { conversations, isLoading, handleConversationClick };
 };

--- a/src/components/shared/itemWithAvatar/index.tsx
+++ b/src/components/shared/itemWithAvatar/index.tsx
@@ -23,6 +23,7 @@ const ItemWithAvatar = ({
   to,
   isLastItem = false,
   isComment = false,
+  ...props
 }: ItemWithAvatarProps) => {
   const renderUnReadCount = () => {
     if (unReadCount) {
@@ -50,7 +51,7 @@ const ItemWithAvatar = ({
 
   return (
     <>
-      <ListItem alignItems="center">
+      <ListItem alignItems="center" {...props}>
         <BasicAvatar size={40} alt={`${name}'s profile`} {...AvatarProps} />
         {to ? (
           <ListItemButton component={Link} to={to ? to : ''}>

--- a/src/components/shared/itemWithAvatar/index.tsx
+++ b/src/components/shared/itemWithAvatar/index.tsx
@@ -7,6 +7,7 @@ import {
   ListItemText,
   Typography,
   ListItemButton,
+  Skeleton,
 } from '@mui/material';
 import styled from '@emotion/styled';
 
@@ -27,13 +28,16 @@ const ItemWithAvatar = ({
 }: ItemWithAvatarProps) => {
   const renderUnReadCount = () => {
     if (unReadCount) {
-      return (
-        <Box maxWidth={60}>
-          <BasicChip label={unReadCount > 999 ? '999+' : String(unReadCount)} />
-        </Box>
-      );
+      if (unReadCount > 0) {
+        return (
+          <Box maxWidth={60}>
+            <BasicChip
+              label={unReadCount > 999 ? '999+' : String(unReadCount)}
+            />
+          </Box>
+        );
+      } else return <SkeletonStyled variant="rounded" width={32} height={32} />;
     }
-    return null;
   };
 
   const renderListItemText = () => (
@@ -70,6 +74,11 @@ const ItemWithAvatar = ({
 
 const BoxStyled = styled(Container)({
   padding: '8px 16px',
+});
+
+const SkeletonStyled = styled(Skeleton)({
+  minWidth: '30px',
+  borderRadius: '16px',
 });
 
 export default ItemWithAvatar;

--- a/src/pages/dm/index.tsx
+++ b/src/pages/dm/index.tsx
@@ -25,7 +25,7 @@ export default function DMListPage() {
             message={conversation.message}
             unReadCount={conversation.unReadCount}
             onClick={() => handleConversationClick(conversation.dmUser)}
-            AvatarProps={{}}
+            AvatarProps={{ imgSrc: conversation.dmUser.image }}
             key={conversation._id}
           />
         ))}

--- a/src/pages/dm/index.tsx
+++ b/src/pages/dm/index.tsx
@@ -1,17 +1,34 @@
-import { List } from '@mui/material';
+import { useCallback } from 'react';
 import styled from '@emotion/styled';
+import List from '@mui/material/List';
+import LinearProgress from '@mui/material/LinearProgress';
 
-import ItemWithAvatar from '@/components/shared/itemWithAvatar';
 import { useDMList } from '@/components/dm/useDMList';
+import ItemWithAvatar from '@/components/shared/itemWithAvatar';
 
 export default function DMListPage() {
-  const { conversations } = useDMList();
+  const { conversations, isLoading, handleConversationClick } = useDMList({
+    onFail: useCallback((error: unknown) => {
+      // TODO: conversations 불러오기 실패 알림
+      console.error(error);
+    }, []),
+  });
 
-  return (
+  return isLoading ? (
+    <LinearProgress />
+  ) : (
     <ListStyled>
-      {conversations.map((conversation) => (
-        <ItemWithAvatar key={conversation._id} {...conversation} />
-      ))}
+      {conversations &&
+        conversations.map((conversation) => (
+          <ItemWithAvatar
+            name={conversation.dmUser.fullName}
+            message={conversation.message}
+            unReadCount={conversation.unReadCount}
+            onClick={() => handleConversationClick(conversation.dmUser)}
+            AvatarProps={{}}
+            key={conversation._id}
+          />
+        ))}
     </ListStyled>
   );
 }

--- a/src/stores/dm/index.ts
+++ b/src/stores/dm/index.ts
@@ -2,5 +2,6 @@ import { dmSlice } from '@/stores/dm/slice';
 import * as selector from '@/stores/dm/selector';
 
 export const dmReducer = dmSlice.reducer;
-export const { setDMUserId, setMessages, addMessage } = dmSlice.actions;
+export const { setConversations, setDMUserId, setMessages, addMessage } =
+  dmSlice.actions;
 export const { dmUserIdSelector, messagesSelector } = selector;

--- a/src/stores/dm/index.ts
+++ b/src/stores/dm/index.ts
@@ -4,4 +4,5 @@ import * as selector from '@/stores/dm/selector';
 export const dmReducer = dmSlice.reducer;
 export const { setConversations, setDMUserId, setMessages, addMessage } =
   dmSlice.actions;
-export const { dmUserIdSelector, messagesSelector } = selector;
+export const { conversationsSelector, dmUserIdSelector, messagesSelector } =
+  selector;

--- a/src/stores/dm/index.ts
+++ b/src/stores/dm/index.ts
@@ -2,7 +2,6 @@ import { dmSlice } from '@/stores/dm/slice';
 import * as selector from '@/stores/dm/selector';
 
 export const dmReducer = dmSlice.reducer;
-export const { setConversations, setDMUserId, setMessages, addMessage } =
-  dmSlice.actions;
+export const { setConversations, setMessages, addMessage } = dmSlice.actions;
 export const { conversationsSelector, dmUserIdSelector, messagesSelector } =
   selector;

--- a/src/stores/dm/selector.ts
+++ b/src/stores/dm/selector.ts
@@ -3,6 +3,7 @@ import { ConversationType, MessageType } from '@/types';
 
 export const conversationsSelector = (state: RootState): ConversationType[] =>
   state.dm.conversations;
-export const dmUserIdSelector = (state: RootState): string => state.dm.dmUserId;
+export const dmUserIdSelector = (state: RootState): string =>
+  state.layout.visitingUser?._id ?? state.layout.location.split('/')[2];
 export const messagesSelector = (state: RootState): MessageType[] =>
   state.dm.messages;

--- a/src/stores/dm/selector.ts
+++ b/src/stores/dm/selector.ts
@@ -1,6 +1,8 @@
 import { RootState } from '@/stores';
-import { MessageType } from '@/types';
+import { ConversationType, MessageType } from '@/types';
 
+export const conversationsSelector = (state: RootState): ConversationType[] =>
+  state.dm.conversations;
 export const dmUserIdSelector = (state: RootState): string => state.dm.dmUserId;
 export const messagesSelector = (state: RootState): MessageType[] =>
   state.dm.messages;

--- a/src/stores/dm/selector.ts
+++ b/src/stores/dm/selector.ts
@@ -1,8 +1,10 @@
 import { RootState } from '@/stores';
-import { ConversationType, MessageType } from '@/types';
+import { MessageType } from '@/types';
+import { ConversationDataType } from '@/stores/dm/slice';
 
-export const conversationsSelector = (state: RootState): ConversationType[] =>
-  state.dm.conversations;
+export const conversationsSelector = (
+  state: RootState,
+): ConversationDataType[] => state.dm.conversations;
 export const dmUserIdSelector = (state: RootState): string =>
   state.layout.visitingUser?._id ?? state.layout.location.split('/')[2];
 export const messagesSelector = (state: RootState): MessageType[] =>

--- a/src/stores/dm/slice.ts
+++ b/src/stores/dm/slice.ts
@@ -1,9 +1,14 @@
 import { createSlice } from '@reduxjs/toolkit';
 
-import { ConversationType, MessageType } from '@/types';
+import { ConversationType, MessageType, UserType } from '@/types';
+
+export interface ConversationDataType extends ConversationType {
+  dmUser?: UserType;
+  unReadCount?: number;
+}
 
 export interface DMState {
-  conversations: ConversationType[];
+  conversations: ConversationDataType[];
   messages: MessageType[];
 }
 

--- a/src/stores/dm/slice.ts
+++ b/src/stores/dm/slice.ts
@@ -1,13 +1,15 @@
 import { createSlice } from '@reduxjs/toolkit';
 
-import { MessageType } from '@/types';
+import { ConversationType, MessageType } from '@/types';
 
 export interface DMState {
+  conversations: ConversationType[];
   dmUserId: string;
   messages: MessageType[];
 }
 
 const initialState: DMState = {
+  conversations: [],
   dmUserId: '',
   messages: [],
 };
@@ -16,6 +18,9 @@ export const dmSlice = createSlice({
   name: 'dm',
   initialState,
   reducers: {
+    setConversations: (state, action) => {
+      state.conversations = action.payload;
+    },
     setDMUserId: (state, action) => {
       state.dmUserId = action.payload;
     },

--- a/src/stores/dm/slice.ts
+++ b/src/stores/dm/slice.ts
@@ -4,13 +4,11 @@ import { ConversationType, MessageType } from '@/types';
 
 export interface DMState {
   conversations: ConversationType[];
-  dmUserId: string;
   messages: MessageType[];
 }
 
 const initialState: DMState = {
   conversations: [],
-  dmUserId: '',
   messages: [],
 };
 
@@ -20,9 +18,6 @@ export const dmSlice = createSlice({
   reducers: {
     setConversations: (state, action) => {
       state.conversations = action.payload;
-    },
-    setDMUserId: (state, action) => {
-      state.dmUserId = action.payload;
     },
     setMessages: (state, action) => {
       state.messages = action.payload;


### PR DESCRIPTION
## 기능 이름
DM List Page 기능 구현

## 기능 설명
DM List Page 기능 구현했습니다.
- 메시지함 불러오기
- 안읽은 메시지 개수 불러오기

DM Detail Page 기능 추가 구현했습니다.
- 메시지 읽음처리 구현

## 구현 내용
https://github.com/prgrms-fe-devcourse/FEDC4_CUCUMIS_Pocojang/assets/49032882/ae4fc335-3101-4507-b338-c53750af8b78

### dmStore
- dmUserId state를 삭제하고 dmUserIdSelector로 layoutStore에서 dmUserId를 가져오게 했습니다.
  - dm 목록에서 이동할 경우 -> visitingUser에서 가져옴
  - url로 바로 이동할 경우 -> location에서 가져옴

### ItemWithAvatar
- to 대신 onClick prop이 필요해서 우선 `...props`로 추가했습니다. 혹시 다른 컴포넌트에 영향이 있다면 말씀해 주세요.
- unReadCount 부분 skeleton 추가했습니다.

## PR 포인트
<!--리뷰어가 집중했으면 하는 부분 -->  

## 참고 사항
메시지함 목록에서 데이터 가공한 부분이 많습니다.

## 궁금한 점
<!-- ## 이슈 번호 - close -->
<!--## 완료 사항-->  

