### PR TITLE
Hotfix/profile post data binding routing

### DIFF
--- a/src/components/profile/profileChangeButton/index.tsx
+++ b/src/components/profile/profileChangeButton/index.tsx
@@ -1,0 +1,39 @@
+import { ChangeCircle } from '@mui/icons-material';
+import { Box, IconButton, styled } from '@mui/material';
+
+interface Type {
+  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  id: string;
+}
+
+const ProfileChangeButton = ({ onChange, id }: Type) => {
+  return (
+    <InputBoxStyled>
+      <input
+        accept="image/*"
+        id={id}
+        type="file"
+        style={{ display: 'none' }}
+        onChange={onChange}
+      />
+      <label htmlFor={id}>
+        <IconButton
+          color="primary"
+          component="span"
+          style={{ whiteSpace: 'nowrap' }}
+        >
+          <ChangeCircle />
+        </IconButton>
+      </label>
+    </InputBoxStyled>
+  );
+};
+
+const InputBoxStyled = styled(Box)({
+  position: 'absolute',
+  left: '0',
+  top: '0',
+  zIndex: '1000',
+});
+
+export default ProfileChangeButton;

--- a/src/components/profile/useProfile.tsx
+++ b/src/components/profile/useProfile.tsx
@@ -1,0 +1,135 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+
+import SESSION_STORAGE from '@/consts/sessionStorage';
+import session from '@/utils/sessionStorage';
+import { UserType } from '@/types';
+import { getUser, uploadUserPhoto } from '@/api/user';
+import { followUser, unFollowUser } from '@/api/follow';
+
+export default function useProfile() {
+  const [myAccount, setMyAccount] = useState(
+    session.getItem<UserType>(SESSION_STORAGE.USER),
+  );
+  const [buttonState, setButtonState] = useState<boolean>();
+  const [userState, setUserState] = useState<UserType>();
+  const navigationData = [
+    { label: userState?.following.length || 0, title: '팔로잉' },
+    { label: userState?.followers.length || 0, title: '팔로워' },
+    { label: userState?.posts.length || 0, title: '포스트' },
+    { label: userState?.likes.length || 0, title: '스크랩' },
+  ];
+  const [value, setValue] = useState<number | string>(0);
+  const [selectedFile, setSelectedFile] = useState<File | null>();
+  const [fileName, setFileName] = useState<string>('파일을 선택하세요.');
+  const { userId } = useParams();
+  const navigate = useNavigate();
+
+  const isMe = (userId: string) => {
+    return myAccount?._id === userId;
+  };
+
+  const checkFollowingStatus = async (buttonState: boolean, userId: string) => {
+    if (!buttonState) {
+      await followUser({ userId }).then(async () => {
+        const updateMyAccount = await getUser(myAccount?._id as string);
+        setMyAccount(updateMyAccount);
+      });
+      const updateMyAccount = await getUser(myAccount?._id as string);
+      setMyAccount(updateMyAccount);
+      setButtonState((prev) => !prev);
+    } else if (buttonState) {
+      const findMe = await getUser(myAccount?._id as string);
+      const followingObj = findMe?.following.find((e) => e.user === userId);
+      await unFollowUser({ id: followingObj?._id as string }).then(async () => {
+        const updateMyAccount = await getUser(myAccount?._id as string);
+        setMyAccount(updateMyAccount);
+      });
+      setButtonState((prev) => !prev);
+    }
+  };
+
+  const isInMyFollowingList = useCallback(
+    async (userId: string) => {
+      const result = myAccount?.following.find((e) => e.user === userId);
+      result ? setButtonState(true) : setButtonState(false);
+      return result;
+    },
+    [myAccount],
+  );
+
+  const goNextPage = (url: string) => {
+    navigate(url);
+  };
+
+  const navigationMoving = (
+    _: React.SyntheticEvent<Element, Event>,
+    newValue: string,
+  ) => {
+    setValue(newValue);
+  };
+
+  const changeProfile = (user: UserType, value: boolean) => {
+    const newObj = { ...userState };
+    if (value) {
+      newObj.coverImage = user.coverImage as string;
+      setMyAccount(newObj as UserType);
+    } else {
+      newObj.image = user.image as string;
+      setMyAccount(newObj as UserType);
+    }
+  };
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    console.log(fileName);
+    if (file) {
+      setFileName(file.name);
+      setSelectedFile(file);
+      handleFileUpload(file, event.target.id);
+    } else {
+      setFileName('파일을 선택하세요.');
+    }
+  };
+
+  const handleFileUpload = async (file: File, id: string) => {
+    const formData = new FormData();
+    formData.append('image', file);
+    formData.append('isCover', String(id === 'profile-photo' ? false : true));
+
+    const upload = await uploadUserPhoto(formData);
+    console.log(selectedFile);
+    changeProfile(upload, id === 'profile-photo' ? false : true);
+  };
+
+  useEffect(() => {
+    const request = async () => {
+      const user = await getUser(userId as string);
+      setUserState(user);
+      isInMyFollowingList(userId as string);
+    };
+    request();
+  }, [userId, isInMyFollowingList, myAccount]);
+
+  useEffect(() => {
+    const resetMyAccount = async () => {
+      const newAccount = await getUser(myAccount?._id as string);
+      setMyAccount(newAccount);
+    };
+    resetMyAccount();
+  }, [myAccount?._id]);
+
+  return {
+    navigationData,
+    value,
+    navigationMoving,
+    userId,
+    userState,
+    buttonState,
+    isMe,
+    checkFollowingStatus,
+    isInMyFollowingList,
+    goNextPage,
+    handleFileChange,
+  };
+}

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -1,10 +1,7 @@
-import { Link, useParams, useNavigate } from 'react-router-dom';
-import Box from '@mui/material/Box';
-import Stack from '@mui/material/Stack';
+import { Link } from 'react-router-dom';
+import { Box, Stack, Skeleton } from '@mui/material';
 import SettingsIcon from '@mui/icons-material/Settings';
-import { useState, useEffect } from 'react';
 import styled from '@emotion/styled';
-import { Stack, Box } from '@mui/material';
 
 import Navbar from '@/components/navbar';
 import ItemWithAvatar from '@/components/shared/itemWithAvatar';
@@ -12,57 +9,70 @@ import ProjectCardItem from '@/components/shared/projectCard';
 import BasicAvatar from '@/components/shared/avatar';
 import BasicButton from '@/components/shared/button';
 import BgProfile from '@/components/profile/bgProfile';
-import { getUser } from '@/api/user';
-import { UserType } from '@/types';
 import ProfileNav from '@/components/profile/profileNav';
+import useProfile from '@/components/profile/useProfile';
+import ProfileChangeButton from '@/components/profile/profileChangeButton';
 
 const ProfilePage = () => {
-  const [currentUser, setCurrentUser] = useState<UserType>();
-  const { userId } = useParams();
-  const navigate = useNavigate();
-  const [value, setValue] = useState<number | string>(0);
-  const navigationData = [
-    { label: currentUser?.following.length || 0, title: '팔로잉' },
-    { label: currentUser?.followers.length || 0, title: '팔로워' },
-    { label: currentUser?.posts.length || 0, title: '포스트' },
-    { label: currentUser?.likes.length || 0, title: '스크랩' },
-  ];
+  const {
+    navigationData,
+    value,
+    navigationMoving,
+    userState,
+    buttonState,
+    checkFollowingStatus,
+    isMe,
+    goNextPage,
+    userId,
+    handleFileChange,
+  } = useProfile();
 
-  const pageMove = (url: string) => {
-    navigate(url);
-  };
-
-  const checkIsMe = () => {
-    const myId = JSON.parse(sessionStorage.getItem('USER') as string);
-    return myId._id === userId;
-  };
-  useEffect(() => {
-    if (userId) {
-      const requestUser = async (userId: string) => {
-        const getUserInfo = await getUser(userId);
-        setCurrentUser(getUserInfo);
-      };
-      requestUser(userId);
-    }
-  }, [userId]);
   return (
     <StyledWrapperBox>
       <StyledBox>
+        {isMe(userId as string) && (
+          <ProfileChangeButton
+            onChange={handleFileChange}
+            id={'background-photo'}
+          />
+        )}
         <BgProfile
           variant="square"
           sx={{ width: '100%', height: '141px' }}
-          src={
-            'https://image.dongascience.com/Photo/2020/03/5bddba7b6574b95d37b6079c199d7101.jpg'
-          }
+          src={userState?.coverImage as string}
         />
         <StyledProfileWrapper>
           <StyledBasicAvatar
-            imgSrc="https://image.dongascience.com/Photo/2020/03/5bddba7b6574b95d37b6079c199d7101.jpg"
+            imgSrc={userState?.image as string}
             alt="프로필사진"
             size={90}
             isUserOn={true}
           />
+          {isMe(userId as string) && (
+            <ProfileChangeButton
+              onChange={handleFileChange}
+              id={'profile-photo'}
+            />
+          )}
         </StyledProfileWrapper>
+        <Stack
+          flexDirection={'row'}
+          alignItems={'center'}
+          justifyContent={'center'}
+        >
+          <h3>
+            {userState ? (
+              userState.fullName
+            ) : (
+              <SkeletonStyled animation="wave" />
+            )}
+          </h3>
+          {isMe(userId as string) && (
+            <Link to="/settings">
+              <SettingsIcon />
+            </Link>
+          )}
+        </Stack>
       </StyledBox>
       <StyledBox>
         <Stack
@@ -70,25 +80,22 @@ const ProfilePage = () => {
           alignItems={'center'}
           justifyContent={'center'}
         >
-          <Box>
-            <Stack
-              direction={'row'}
-              alignItems={'center'}
-              justifyContent={'center'}
-            >
-              <p>이름</p>
-              <Link to="/settings">
-                <SettingsIcon />
-              </Link>
-            </Stack>
-          </Box>
-          {checkIsMe() || (
+          {isMe(userId as string) || (
             <StyledBasicButtonStack direction={'row'}>
-              <BasicButton variant="outlined" children="팔로우" />
+              <BasicButton
+                variant="outlined"
+                children={buttonState ? '팔로잉 취소' : '팔로잉'}
+                onClick={async () => {
+                  await checkFollowingStatus(
+                    buttonState as boolean,
+                    userId as string,
+                  );
+                }}
+              />
               <BasicButton
                 variant="outlined"
                 children="DM"
-                onClick={() => pageMove(`/dm/${userId}`)}
+                onClick={() => goNextPage(`/dm/${userId}`)}
               />
             </StyledBasicButtonStack>
           )}
@@ -98,15 +105,13 @@ const ProfilePage = () => {
         <ProfileNav
           value={value}
           navigationData={navigationData}
-          onChange={(_, newValue) => {
-            setValue(newValue);
-          }}
+          onChange={navigationMoving}
         />
         <StyledContentsWrapper>
           {value === 0 ? (
             <StyledItemWithAvatarBox>
-              {currentUser &&
-                currentUser.following.map(({ user }) => {
+              {userState &&
+                userState.following.map(({ user }) => {
                   return (
                     <ItemWithAvatar
                       name={user}
@@ -120,8 +125,8 @@ const ProfilePage = () => {
             </StyledItemWithAvatarBox>
           ) : value === 1 ? (
             <StyledItemWithAvatarBox>
-              {currentUser &&
-                currentUser.followers.map(({ follower }) => {
+              {userState &&
+                userState.followers.map(({ follower }) => {
                   return (
                     <ItemWithAvatar
                       name={follower}
@@ -135,8 +140,8 @@ const ProfilePage = () => {
             </StyledItemWithAvatarBox>
           ) : value === 2 ? (
             <>
-              {currentUser &&
-                currentUser.posts.map(({ _id, title, image }) => (
+              {userState &&
+                userState.posts.map(({ _id, title, image }) => (
                   <StyledProjectCardItemBox key={_id}>
                     <ProjectCardItem
                       name={title}
@@ -149,8 +154,8 @@ const ProfilePage = () => {
             </>
           ) : (
             <>
-              {currentUser &&
-                currentUser.posts.map(({ _id, title, image }) => (
+              {userState &&
+                userState.posts.map(({ _id, title, image }) => (
                   <StyledProjectCardItemBox key={_id}>
                     <ProjectCardItem
                       name={title}
@@ -213,12 +218,13 @@ const StyledItemWithAvatarBox = styled(Box)({
   height: '100%',
 });
 
-// const StyledProjectCardItem = styled(ProjectCardItem)({
-//   border: '3px solid black',
-// });
 const StyledProjectCardItemBox = styled(Box)({
   width: '90%',
   margin: '10px auto',
 });
 
+const SkeletonStyled = styled(Skeleton)({
+  width: '100%',
+  height: '100%',
+});
 export default ProfilePage;

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -144,10 +144,10 @@ const ProfilePage = () => {
                 userState.posts.map(({ _id, title, image }) => (
                   <StyledProjectCardItemBox key={_id}>
                     <ProjectCardItem
-                      name={title}
+                      name={JSON.parse(title).requirements}
                       imageUrl={image as string}
                       to={`${_id}`}
-                      projectTitle={title}
+                      projectTitle={JSON.parse(title).title}
                     />
                   </StyledProjectCardItemBox>
                 ))}

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -146,7 +146,7 @@ const ProfilePage = () => {
                     <ProjectCardItem
                       name={title}
                       imageUrl={image as string}
-                      to={`/projects/${_id}`}
+                      to={`${_id}`}
                       projectTitle={title}
                     />
                   </StyledProjectCardItemBox>
@@ -160,7 +160,7 @@ const ProfilePage = () => {
                     <ProjectCardItem
                       name={title}
                       imageUrl={image as string}
-                      to={`/projects/${_id}`}
+                      to={`${_id}`}
                       projectTitle={title}
                     />
                   </StyledProjectCardItemBox>


### PR DESCRIPTION
## 기능 이름
데이터 바인딩 + 라우팅 버그 해결

## 기능 설명
<li>
Profile페이지 내에 있는 포스팅 탭에서 잘못된 데이터를 바인딩 해주고 있어서 수정했습니다.
<li>
<li>
포스팅된 리스트를 눌렀을 때 /projects/id로 가지않고, /projects/id/projects/id 2번이 반복이 돼서 url문제 해결했습니다. 
<li>
## 구현 내용
<!-- ## 스크린샷 - UI 관련인 경우 꼭 넣기! -->
<!-- ## 장애물 - 기능 구현 중 있었던 이슈 -->  
<h2>잘못된 데이터 바인딩 문제 해결</h2>
<img width="611" alt="image" src="https://github.com/prgrms-fe-devcourse/FEDC4_CUCUMIS_Pocojang/assets/85999976/a83dc1d0-1a35-4f6a-9f17-17516016c705">

<h2>클릭 시 잘못된 url로 가버리는 문제 해결</h2>
<img width="608" alt="image" src="https://github.com/prgrms-fe-devcourse/FEDC4_CUCUMIS_Pocojang/assets/85999976/9b38f0dd-ed15-4bcb-9c2a-084d4983e90f">

## PR 포인트
<!--리뷰어가 집중했으면 하는 부분 -->  
Profile/posting탭에서 클릭시 project/id로 잘 이동하는지, 잘못된 데이터가 바인딩 되고있지는 않은지 확인 부탁드립니다!

## 참고 사항
<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->  


## 궁금한 점
<!-- ## 이슈 번호 - close -->
<!--## 완료 사항-->  
데이터 바인딩 에러 + 라우팅 에러 해결

