### PR TITLE
Hotfix/162 project detail page exception handling

### DIFF
--- a/src/components/comments/useComment.ts
+++ b/src/components/comments/useComment.ts
@@ -1,22 +1,21 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { useAppSelector } from '@/stores/hooks';
 import { layoutSelector } from '@/stores/layout';
 import { createComment, deleteComment } from '@/api/comments';
-import session from '@/utils/sessionStorage';
-import type { UserType } from '@/types';
-import SESSION_STORAGE from '@/consts/sessionStorage';
 import { sendNotification } from '@/api/notifications';
 import { projectDetailSelector } from '@/stores/projectDetail/selector';
 import { LOGIN_URL, PROFILE_URL } from '@/consts/routes';
 import { tokenSelector } from '@/stores/auth/selector';
+import { userIdSelector } from '@/stores/auth';
 
 const useComment = () => {
   const { post } = useAppSelector(projectDetailSelector);
   const { input } = useAppSelector(layoutSelector);
   const token = useAppSelector(tokenSelector);
-  const [userId, setUserId] = useState('');
+  const userId = useAppSelector(userIdSelector);
+
   const navigate = useNavigate();
 
   const handleDeleteClick = async (id: string) => {
@@ -32,47 +31,37 @@ const useComment = () => {
     navigate(PROFILE_URL + id);
   };
 
-  useEffect(() => {
-    const user = session.getItem<UserType>(SESSION_STORAGE.USER);
+  const submitComment = useCallback(async () => {
+    if (!token) {
+      window.alert('로그인이 필요합니다');
 
-    if (user) {
-      const { _id } = user;
+      navigate(LOGIN_URL);
 
-      setUserId(_id);
+      return;
     }
-  }, []);
+
+    try {
+      const res = await createComment({
+        comment: input,
+        postId: post.postId,
+      });
+
+      await sendNotification({
+        notificationType: 'COMMENT',
+        notificationTypeId: res._id,
+        userId: post.author._id as string,
+        postId: post.postId,
+      });
+
+      navigate(0);
+    } catch (error) {
+      window.alert('댓글 달기에 실패하였습니다');
+    }
+  }, [token, input, navigate, post.author._id, post.postId]);
 
   useEffect(() => {
-    const submitComment = async () => {
-      if (!token) {
-        window.alert('로그인이 필요합니다');
-
-        navigate(LOGIN_URL);
-
-        return;
-      }
-
-      try {
-        const res = await createComment({
-          comment: input,
-          postId: post.postId,
-        });
-
-        await sendNotification({
-          notificationType: 'COMMENT',
-          notificationTypeId: res._id,
-          userId: post.author._id as string,
-          postId: post.postId,
-        });
-
-        navigate(0);
-      } catch (error) {
-        window.alert('댓글 달기에 실패하였습니다');
-      }
-    };
-
     input && submitComment();
-  }, [token, input, userId, navigate, post.author._id, post.postId]);
+  }, [input, submitComment]);
 
   return {
     comments: post.comments,

--- a/src/components/comments/useComment.ts
+++ b/src/components/comments/useComment.ts
@@ -23,7 +23,7 @@ const useComment = () => {
     try {
       await deleteComment({ id });
     } catch (error) {
-      console.log(error);
+      window.alert('댓글 삭제에 실패하였습니다');
     }
     navigate(0);
   };
@@ -67,7 +67,7 @@ const useComment = () => {
 
         navigate(0);
       } catch (error) {
-        console.log(error);
+        window.alert('댓글 달기에 실패하였습니다');
       }
     };
 

--- a/src/components/comments/useComment.ts
+++ b/src/components/comments/useComment.ts
@@ -9,11 +9,13 @@ import type { UserType } from '@/types';
 import SESSION_STORAGE from '@/consts/sessionStorage';
 import { sendNotification } from '@/api/notifications';
 import { projectDetailSelector } from '@/stores/projectDetail/selector';
-import { PROFILE_URL } from '@/consts/routes';
+import { LOGIN_URL, PROFILE_URL } from '@/consts/routes';
+import { tokenSelector } from '@/stores/auth/selector';
 
 const useComment = () => {
   const { post } = useAppSelector(projectDetailSelector);
   const { input } = useAppSelector(layoutSelector);
+  const token = useAppSelector(tokenSelector);
   const [userId, setUserId] = useState('');
   const navigate = useNavigate();
 
@@ -42,6 +44,14 @@ const useComment = () => {
 
   useEffect(() => {
     const submitComment = async () => {
+      if (!token) {
+        window.alert('로그인이 필요합니다');
+
+        navigate(LOGIN_URL);
+
+        return;
+      }
+
       try {
         const res = await createComment({
           comment: input,
@@ -62,7 +72,7 @@ const useComment = () => {
     };
 
     input && submitComment();
-  }, [input, userId, navigate, post.author._id, post.postId]);
+  }, [token, input, userId, navigate, post.author._id, post.postId]);
 
   return {
     comments: post.comments,

--- a/src/components/projects/useProjectDetail.ts
+++ b/src/components/projects/useProjectDetail.ts
@@ -11,15 +11,7 @@ import { projectDetailSelector } from '@/stores/projectDetail/selector';
 import type { PostType, FormattedPost, ProjectContent } from '@/types';
 import { PROFILE_URL, PROJECT_MODIFYL_URL, PROJECT_URL } from '@/consts/routes';
 
-interface ProjectDetailHookParameters {
-  onGetFail: (error: unknown) => void;
-  onSendFail: (error: unknown) => void;
-}
-
-const useProjectDetail = ({
-  onGetFail,
-  onSendFail,
-}: ProjectDetailHookParameters) => {
+const useProjectDetail = () => {
   const navigate = useNavigate();
   const dispatch = useDispatch();
 
@@ -48,7 +40,7 @@ const useProjectDetail = ({
 
         res && navigate(PROJECT_URL);
       } catch (error) {
-        onSendFail(error);
+        window.alert('포스트 삭제에 실패하였습니다');
       }
     }
   };
@@ -62,20 +54,19 @@ const useProjectDetail = ({
 
         dispatch(setPost(formattedPost));
       } catch (error) {
-        onGetFail(error);
         setError('존재하지 않는 포스트입니다');
       } finally {
         setIsLoading(false);
       }
     },
-    [dispatch, onGetFail],
+    [dispatch],
   );
 
   useEffect(() => {
     if (projectId) {
       fetchPost(projectId);
     }
-  }, [projectId, dispatch, fetchPost, onGetFail]);
+  }, [projectId, fetchPost]);
 
   useEffect(() => {
     if (error) {

--- a/src/components/projects/useProjectDetail.ts
+++ b/src/components/projects/useProjectDetail.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
+import { AxiosError } from 'axios';
 
 import { getPost, deletePost } from '@/api/posts';
 import { setPost } from '@/stores/projectDetail';
@@ -27,6 +28,7 @@ const useProjectDetail = ({
   const userId = useAppSelector(userIdSelector);
 
   const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState('');
 
   const handleAvatarClick = () => {
     navigate(PROFILE_URL + post.author._id);
@@ -61,6 +63,7 @@ const useProjectDetail = ({
         dispatch(setPost(formattedPost));
       } catch (error) {
         onGetFail(error);
+        setError('존재하지 않는 포스트입니다');
       } finally {
         setIsLoading(false);
       }
@@ -73,6 +76,12 @@ const useProjectDetail = ({
       fetchPost(projectId);
     }
   }, [projectId, dispatch, fetchPost, onGetFail]);
+
+  useEffect(() => {
+    if (error) {
+      throw new AxiosError(error);
+    }
+  }, [error]);
 
   return {
     projectId,

--- a/src/components/projects/useProjectDetail.ts
+++ b/src/components/projects/useProjectDetail.ts
@@ -32,13 +32,12 @@ const useProjectDetail = () => {
 
   const handleDeleteClick = async () => {
     const ableToDelete = confirm('정말로 삭제하시겠습니까?');
-    // 모달로 변경 필요?
 
     if (ableToDelete && projectId) {
       try {
         const res = await deletePost({ id: projectId });
 
-        res && navigate(PROJECT_URL);
+        res && navigate(PROJECT_URL, { replace: true });
       } catch (error) {
         window.alert('포스트 삭제에 실패하였습니다');
       }

--- a/src/components/projects/useProjectDetail.ts
+++ b/src/components/projects/useProjectDetail.ts
@@ -10,6 +10,7 @@ import { useAppSelector } from '@/stores/hooks';
 import { projectDetailSelector } from '@/stores/projectDetail/selector';
 import type { PostType, FormattedPost, ProjectContent } from '@/types';
 import { PROFILE_URL, PROJECT_MODIFYL_URL, PROJECT_URL } from '@/consts/routes';
+import handleAxiosError from '@/utils/axiosError';
 
 const useProjectDetail = () => {
   const navigate = useNavigate();
@@ -20,7 +21,7 @@ const useProjectDetail = () => {
   const userId = useAppSelector(userIdSelector);
 
   const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState('');
+  const [errorMessage, setErrorMessage] = useState('');
 
   const handleAvatarClick = () => {
     navigate(PROFILE_URL + post.author._id);
@@ -53,15 +54,9 @@ const useProjectDetail = () => {
 
         dispatch(setPost(formattedPost));
       } catch (error: unknown) {
-        if (error instanceof AxiosError) {
-          if (error.response?.status === 502) {
-            setError('존재하지 않는 포스트입니다');
-          } else {
-            setError('새로고침 해주세요');
-          }
-        } else {
-          setError('알 수 없는 오류 발생! 다시 접속해주세요');
-        }
+        const axiosErrorMessage = handleAxiosError(error as Error);
+
+        setErrorMessage(axiosErrorMessage);
       } finally {
         setIsLoading(false);
       }
@@ -76,10 +71,10 @@ const useProjectDetail = () => {
   }, [projectId, fetchPost]);
 
   useEffect(() => {
-    if (error) {
-      throw new AxiosError(error);
+    if (errorMessage) {
+      throw new AxiosError(errorMessage);
     }
-  }, [error]);
+  }, [errorMessage]);
 
   return {
     projectId,

--- a/src/components/projects/useProjectDetail.ts
+++ b/src/components/projects/useProjectDetail.ts
@@ -31,7 +31,7 @@ const useProjectDetail = () => {
   };
 
   const handleDeleteClick = async () => {
-    const ableToDelete = confirm('정말로 삭제하시겠습니까?');
+    const ableToDelete = window.confirm('정말로 삭제하시겠습니까?');
 
     if (ableToDelete && projectId) {
       try {
@@ -52,8 +52,16 @@ const useProjectDetail = () => {
         const formattedPost = handlePostFormat(rs);
 
         dispatch(setPost(formattedPost));
-      } catch (error) {
-        setError('존재하지 않는 포스트입니다');
+      } catch (error: unknown) {
+        if (error instanceof AxiosError) {
+          if (error.response?.status === 502) {
+            setError('존재하지 않는 포스트입니다');
+          } else {
+            setError('새로고침 해주세요');
+          }
+        } else {
+          setError('알 수 없는 오류 발생! 다시 접속해주세요');
+        }
       } finally {
         setIsLoading(false);
       }

--- a/src/consts/routes.ts
+++ b/src/consts/routes.ts
@@ -4,3 +4,4 @@ export const SETTINGS_URL = '/settings';
 export const DM_URL = '/dm/';
 export const DEVELOPER_URL = '/developers';
 export const PROJECT_URL = '/projects';
+export const LOGIN_URL = '/login';

--- a/src/pages/notFound/index.tsx
+++ b/src/pages/notFound/index.tsx
@@ -1,7 +1,11 @@
 import styled from '@emotion/styled';
 import { Box, Checkbox, Typography } from '@mui/material';
+import { AxiosError } from 'axios';
+import { useRouteError } from 'react-router-dom';
 
 export default function NotFoundPage() {
+  const error = useRouteError();
+
   return (
     <BoxStyled>
       <CheckboxStyled
@@ -13,7 +17,9 @@ export default function NotFoundPage() {
         404 Not Found
       </TitleStyled>
       <TypographyStyled variant="body2" component="p" color="gray">
-        페이지를 찾을 수 없습니다
+        {error instanceof AxiosError
+          ? error.message
+          : '페이지를 찾을 수 없습니다'}
       </TypographyStyled>
     </BoxStyled>
   );

--- a/src/pages/projects/[projectId].tsx
+++ b/src/pages/projects/[projectId].tsx
@@ -1,4 +1,3 @@
-import { useCallback } from 'react';
 import styled from '@emotion/styled';
 import { Box, Divider, LinearProgress, Stack, Typography } from '@mui/material';
 
@@ -21,15 +20,7 @@ export default function ProjectDetailPage() {
     handleDeleteClick,
     isAuthor,
     isLoading,
-  } = useProjectDetail({
-    onGetFail: useCallback((error: unknown) => {
-      console.error(error);
-      // 잘못된 접근 모달 팝업 또는  navigate('/project');
-    }, []),
-    onSendFail: useCallback((error: unknown) => {
-      console.error(error);
-    }, []),
-  });
+  } = useProjectDetail();
 
   return isLoading ? (
     <LinearProgress />

--- a/src/utils/axiosError.ts
+++ b/src/utils/axiosError.ts
@@ -1,0 +1,14 @@
+import { AxiosError } from 'axios';
+
+const handleAxiosError = (error: Error) => {
+  if (error instanceof AxiosError) {
+    if (error.response?.status === 502) {
+      return '존재하지 않는 포스트입니다';
+    } else {
+      return '새로고침 해주세요';
+    }
+  }
+  return '알 수 없는 오류 발생! 다시 접속해주세요';
+};
+
+export default handleAxiosError;


### PR DESCRIPTION
## 기능 이름
프로젝트 상세 페이지 예외처리

## 기능 설명
- 존재하지 않는 post 접속 시 Notfound 예외처리
- 포스트 삭제 시 뒤로가기 막기
- 포스트 삭제 실패 시 알림
- 댓글 api 호출 실패 알림

## 구현 내용
<!-- ## 스크린샷 - UI 관련인 경우 꼭 넣기! -->
<!-- ## 장애물 - 기능 구현 중 있었던 이슈 -->  
- 존재하지 않는 post : http://localhost:3000/projects/1234wrong
![image](https://github.com/prgrms-fe-devcourse/FEDC4_CUCUMIS_Pocojang/assets/87280835/b75ccb34-da28-4973-af05-2990cfc7a91b)

- 잘못된 url : http://localhost:3000/projects/한글
![image](https://github.com/prgrms-fe-devcourse/FEDC4_CUCUMIS_Pocojang/assets/87280835/9ab52deb-379e-4ea2-8c02-2d4febef706d)

- api 응답 실패 시 '새로고침 해주세요' 메세지가 보임
## PR 포인트
<!--리뷰어가 집중했으면 하는 부분 -->  


## 참고 사항
<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->  
- 댓글 달기/삭제 시 로딩은 부가기능에서 추가하겠습니다!

## 궁금한 점
<!-- ## 이슈 번호 - close -->
<!--## 완료 사항-->  
- 더 좋은 예외처리 방법이나 빠진 부분이 있다면 알려주세요
