### PR TITLE
Fix/177 project image upload

### DIFF
--- a/src/components/projects/projectPost.tsx
+++ b/src/components/projects/projectPost.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from 'react-router-dom';
-import { Button, Box, Stack, LinearProgress } from '@mui/material';
+import { Button, Box, Stack, LinearProgress, Typography } from '@mui/material';
 import styled from '@emotion/styled';
+import CloseIcon from '@mui/icons-material/Close';
 
 import BasicInput from '@/components/shared/input';
 import usePost from '@/components/projects/usePost';
@@ -23,7 +24,9 @@ export default function ProjectPost() {
     setIsLoading,
     handleFileChange,
     selectedFile,
+    fileName,
     imageFile,
+    handleDeleteFileData,
   } = usePost();
 
   const { errors, handleChange, handleSubmit } = useForm({
@@ -86,7 +89,11 @@ export default function ProjectPost() {
       <Stack spacing={3}>
         <Box />
         {imageFile ? (
-          <PreviewImageBox src={imageFile} alt="프로필 이미지" />
+          <PreviewImageBox
+            src={imageFile}
+            alt="프로필 이미지"
+            onClick={handleDeleteFileData}
+          />
         ) : (
           <UploadStyledButton variant="outlined" component="label">
             <Box>Click to Upload</Box>
@@ -98,6 +105,12 @@ export default function ProjectPost() {
               onChange={handleFileChange}
             />
           </UploadStyledButton>
+        )}
+        {fileName && (
+          <Stack direction="row" spacing={1}>
+            <Typography>{fileName}</Typography>
+            <CloseIcon color="secondary" onClick={handleDeleteFileData} />
+          </Stack>
         )}
         <BasicInput
           defaultValue={prevTitle}

--- a/src/components/projects/usePost.ts
+++ b/src/components/projects/usePost.ts
@@ -21,10 +21,18 @@ const usePost = () => {
   const navigate = useNavigate();
 
   const [isLoading, setIsLoading] = useState(false);
-  const [authorId, setAuthorId] = useState('');
-  const [contents, setContents] = useState({ title: '', requirements: '' });
-  const [selectedFile, setSelectedFile] = useState<File | null>(null);
-  const [imageFile, setImageFile] = useState<string | null>(null);
+  const [contents, setContents] = useState({
+    title: '',
+    requirements: '',
+    authorId: '',
+  });
+  const [fileData, setFileData] = useState<{
+    selectedFile: File | null;
+    imageFile: string | null;
+  }>({
+    selectedFile: null,
+    imageFile: null,
+  });
   const [errorMessage, setErrorMessage] = useState('');
 
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -32,12 +40,13 @@ const usePost = () => {
       const file = event.target.files[0] || null;
 
       if (file) {
-        setSelectedFile(file);
-
         const reader = new FileReader();
         reader.readAsDataURL(file);
         reader.onloadend = () => {
-          setImageFile(reader.result as string);
+          setFileData({
+            selectedFile: file,
+            imageFile: reader.result as string,
+          });
         };
       }
     }
@@ -61,18 +70,17 @@ const usePost = () => {
 
   const handlePost = (rs: PostType) => {
     const { title, requirements } = JSON.parse(rs.title);
-    setContents({ title, requirements });
 
-    setAuthorId(rs.author._id);
+    setContents({ title, requirements, authorId: rs.author._id });
   };
 
   useEffect(() => {
     if (!isLogin) {
       navigate(LOGIN_URL);
-    } else if (authorId && userId !== authorId) {
+    } else if (contents.authorId && userId !== contents.authorId) {
       throw new Error('잘못된 접근입니다');
     }
-  }, [isLogin, navigate, userId, authorId]);
+  }, [isLogin, navigate, userId, contents.authorId]);
 
   useEffect(() => {
     projectId && fetchPost(projectId);
@@ -91,8 +99,7 @@ const usePost = () => {
     isLoading,
     setIsLoading,
     handleFileChange,
-    selectedFile,
-    imageFile,
+    ...fileData,
   };
 };
 

--- a/src/components/projects/usePost.ts
+++ b/src/components/projects/usePost.ts
@@ -16,9 +16,10 @@ export interface ProjectContent {
 
 const usePost = () => {
   const { projectId } = useParams();
+  const navigate = useNavigate();
+
   const userId = useAppSelector(userIdSelector);
   const isLogin = useAppSelector(isLoginSelector);
-  const navigate = useNavigate();
 
   const [isLoading, setIsLoading] = useState(false);
   const [contents, setContents] = useState({
@@ -29,9 +30,11 @@ const usePost = () => {
   const [fileData, setFileData] = useState<{
     selectedFile: File | null;
     imageFile: string | null;
+    fileName: string;
   }>({
     selectedFile: null,
     imageFile: null,
+    fileName: '',
   });
   const [errorMessage, setErrorMessage] = useState('');
 
@@ -46,6 +49,7 @@ const usePost = () => {
           setFileData({
             selectedFile: file,
             imageFile: reader.result as string,
+            fileName: file.name,
           });
         };
       }
@@ -71,7 +75,19 @@ const usePost = () => {
   const handlePost = (rs: PostType) => {
     const { title, requirements } = JSON.parse(rs.title);
 
+    setFileData((prev) => ({
+      ...prev,
+      imageFile: rs.image ?? null,
+      fileName: rs.image
+        ? 'image : ' + rs.createdAt.replace('T', ' ').slice(0, -5)
+        : '',
+    }));
+
     setContents({ title, requirements, authorId: rs.author._id });
+  };
+
+  const handleDeleteFileData = () => {
+    setFileData({ selectedFile: null, imageFile: null, fileName: '' });
   };
 
   useEffect(() => {
@@ -99,6 +115,7 @@ const usePost = () => {
     isLoading,
     setIsLoading,
     handleFileChange,
+    handleDeleteFileData,
     ...fileData,
   };
 };


### PR DESCRIPTION
## 기능 이름
프로젝트 이미지 재업로드

## 기능 설명
- 이미지 이름 보기
  - 글 수정 시에는 api에서 이미지 이름을 반환하지 않아서 포스팅 날짜를 이미지 이름으로 설정해두었습니다.
- 이미지나 x버튼 클릭 시 이미지 재업로드 가능

## 구현 내용
<!-- ## 스크린샷 - UI 관련인 경우 꼭 넣기! -->
<!-- ## 장애물 - 기능 구현 중 있었던 이슈 -->  

![image](https://github.com/prgrms-fe-devcourse/FEDC4_CUCUMIS_Pocojang/assets/87280835/49f56784-fcef-4dee-bb86-c5382fb21d0f)

## PR 포인트
<!--리뷰어가 집중했으면 하는 부분 -->  


## 참고 사항
<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->  


## 궁금한 점
<!-- ## 이슈 번호 - close -->
<!--## 완료 사항-->  

