### PR TITLE
Hotfix/180 conversation type

### DIFF
--- a/src/pages/dm/index.tsx
+++ b/src/pages/dm/index.tsx
@@ -19,14 +19,14 @@ export default function DMListPage() {
   ) : (
     <ListStyled>
       {conversations &&
-        conversations.map((conversation) => (
+        conversations.map(({ dmUser, message, unReadCount }) => (
           <ItemWithAvatar
-            name={conversation.dmUser.fullName}
-            message={conversation.message}
-            unReadCount={conversation.unReadCount}
-            onClick={() => handleConversationClick(conversation.dmUser)}
-            AvatarProps={{ imgSrc: conversation.dmUser.image }}
-            key={conversation._id}
+            name={dmUser.fullName}
+            message={message}
+            unReadCount={unReadCount}
+            onClick={() => handleConversationClick(dmUser)}
+            AvatarProps={{ imgSrc: dmUser.image }}
+            key={dmUser._id}
           />
         ))}
     </ListStyled>

--- a/src/stores/dm/slice.ts
+++ b/src/stores/dm/slice.ts
@@ -3,8 +3,8 @@ import { createSlice } from '@reduxjs/toolkit';
 import { ConversationType, MessageType, UserType } from '@/types';
 
 export interface ConversationDataType extends ConversationType {
-  dmUser?: UserType;
-  unReadCount?: number;
+  dmUser: UserType;
+  unReadCount: number;
 }
 
 export interface DMState {

--- a/src/types/components/ItemWithAvatarProps.ts
+++ b/src/types/components/ItemWithAvatarProps.ts
@@ -11,4 +11,5 @@ export default interface ItemWithAvatarProps {
   to?: string;
   isLastItem?: boolean;
   isComment?: boolean;
+  onClick?: () => void;
 }


### PR DESCRIPTION
## 기능 이름
conversation 타입 에러 수정

## 기능 설명
빌드 과정에서 발생한 conversations 타입 에러 수정했습니다.
빌드 테스트 완료했습니다!

## 구현 내용

## PR 포인트

## 참고 사항

`ItemWithAvatarProps` onClick 타입 추가했습니다.
```typescript
export default interface ItemWithAvatarProps {
  children?: ReactNode;
  AvatarProps: BasicAvatarProps;
  name: string;
  message?: string;
  unReadCount?: number;
  to?: string;
  isLastItem?: boolean;
  isComment?: boolean;
  onClick?: () => void;
}

```

## 궁금한 점
<!-- ## 이슈 번호 - close -->
<!--## 완료 사항-->  

