### PR TITLE
refactor : profile navigation tab 4개에서 3개로 수정

### DIFF
--- a/src/components/profile/navigationProfileContent/index.tsx
+++ b/src/components/profile/navigationProfileContent/index.tsx
@@ -30,7 +30,7 @@ const NavigationProfileContent = ({ userState, value }: Type) => {
                 to={`/profile/${follower}`}
               />
             ))}
-          {['2', '3'].includes(value) &&
+          {value === '2' &&
             userState.posts.map(({ _id, title, image }) => (
               <Box key={_id}>
                 <ProjectCardItem

--- a/src/components/profile/useProfile.ts
+++ b/src/components/profile/useProfile.ts
@@ -39,7 +39,6 @@ export default function useProfile() {
     { label: userState?.following.length || 0, title: '팔로잉' },
     { label: userState?.followers.length || 0, title: '팔로워' },
     { label: userState?.posts.length || 0, title: '포스트' },
-    { label: userState?.likes.length || 0, title: '스크랩' },
   ];
 
   const isMe = (userId: string) => myAccount?._id === userId;


### PR DESCRIPTION
## 기능 이름
프로필 navigation tab 4개에서, 팔로잉, 팔로워, 포스트 3개만 남겨두기

## 기능 설명
프로필 네비게이션 탭의 개수를 4개에서 3개로 줄였습니다.

## 구현 내용
<!-- ## 스크린샷 - UI 관련인 경우 꼭 넣기! -->
<!-- ## 장애물 - 기능 구현 중 있었던 이슈 -->  
<h1>프로필 네브바 탭 3개로 수정</h1>
<img width="686" alt="image" src="https://github.com/prgrms-fe-devcourse/FEDC4_CUCUMIS_Pocojang/assets/85999976/717e1454-b460-4688-856c-bf85c4cf4635">


## PR 포인트
<!--리뷰어가 집중했으면 하는 부분 -->  
네브바 탭 개수만 보시면 됩니다

## 참고 사항
<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->  


## 궁금한 점
<!-- ## 이슈 번호 - close -->
#187 
<!--## 완료 사항-->  
네브바 탭 4개에서 3개로 변경
