### PR TITLE
fix: profile 값을 수정하지 않았을 때, defaultValue 를 가져오지 못하는 버그 수정

### DIFF
--- a/src/components/settings/profile/useSettingsProfileForm.ts
+++ b/src/components/settings/profile/useSettingsProfileForm.ts
@@ -33,21 +33,20 @@ interface SettingsProfileFormParameters {
 
 const updateProfile = (
   profilePostId: string,
-  name: string,
   formData: FormData,
 ): Promise<[PostType, UserType]> =>
   Promise.all([
     updatePost(formData),
-    updateUser({ fullName: name, username: profilePostId }),
+    updateUser({
+      fullName: formData.get('name') as string,
+      username: profilePostId,
+    }),
   ]);
 
-const createProfile = async (
-  name: string,
-  formData: FormData,
-): Promise<UserType> => {
+const createProfile = async (formData: FormData): Promise<UserType> => {
   const profilePost = await createPost(formData);
   const userData = await updateUser({
-    fullName: name,
+    fullName: formData.get('name') as string,
     username: profilePost._id,
   });
   return userData;
@@ -78,10 +77,11 @@ const useSettingsProfileForm = ({
       settingsProfileFormValues;
 
     const title = JSON.stringify({
-      oneLiner: oneLiner ?? defaultValues.oneLiner,
-      techStack: techStack ?? defaultValues.techStack,
-      position: position ?? defaultValues.position,
-      details: details ?? defaultValues.details,
+      name: name || defaultValues.name,
+      oneLiner: oneLiner || defaultValues.oneLiner,
+      techStack: techStack || defaultValues.techStack,
+      position: position || defaultValues.position,
+      details: details || defaultValues.details,
     });
     formData.append('title', title);
     formData.append('channelId', CHANNEL_ID.DEVELOPER);
@@ -89,9 +89,9 @@ const useSettingsProfileForm = ({
     try {
       if (profilePostId) {
         formData.append('postId', profilePostId);
-        await updateProfile(profilePostId, name, formData);
+        await updateProfile(profilePostId, formData);
       } else {
-        const userData = await createProfile(name, formData);
+        const userData = await createProfile(formData);
         dispatch(setUser(userData));
       }
       onSuccess();


### PR DESCRIPTION
## 기능 이름
`profile` 값을 수정하지 않았을 때, `defaultValue` 를 가져오지 못하는 버그 수정

## 기능 설명
기존의 `nullish` 연산자를 사용해서, 값이 `null` 이거나 `undefined` 일때만 `defaultValue` 를 가져오도록 했던 코드를
`or` 연산자를 사용하여 `falsy` 한 값일때도 `defaultValue`를 가져오도록 수정하여 버그를 해결했습니다.


## 구현 내용
<!-- ## 스크린샷 - UI 관련인 경우 꼭 넣기! -->
<!-- ## 장애물 - 기능 구현 중 있었던 이슈 -->  


## PR 포인트
<!--리뷰어가 집중했으면 하는 부분 -->  


## 참고 사항
<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->  


## 궁금한 점
<!-- ## 이슈 번호 - close -->
<!--## 완료 사항-->  

